### PR TITLE
include mysql master host in slave metrics

### DIFF
--- a/src/metrics.go
+++ b/src/metrics.go
@@ -146,6 +146,7 @@ var slaveMetrics = map[string][]interface{}{
 	"cluster.relayMasterLogFile":  {"Relay_Master_Log_File", metric.ATTRIBUTE},
 	"cluster.execMasterLogPos":    {"Exec_Master_Log_Pos", metric.GAUGE},
 	"db.relayLogSpace":            {"Relay_Log_Space", metric.GAUGE},
+	"cluster.masterHost":          {"Master_Host", metric.ATTRIBUTE},
 }
 
 var innodbMetrics = map[string][]interface{}{


### PR DESCRIPTION
mysql master that the server is slaving from. This is really helpful
when trying to diagnose slave replication issues so I added a single
line to include that metric output.

