### PR TITLE
Fix make failure of lacking dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TARGET_DIR       = $(WORKDIR)/$(TARGET)
 
 all: build
 
-build: clean validate compile test
+build: clean validate-deps validate compile test
 
 clean:
 	@echo "=== $(INTEGRATION) === [ clean ]: removing binaries and coverage file..."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 INTEGRATION     := mysql
 BINARY_NAME      = nr-$(INTEGRATION)
 SRC_DIR					 = ./src/
-VALIDATE_DEPS    = github.com/golang/lint/golint
+VALIDATE_DEPS    = golang.org/x/lint/golint
 TEST_DEPS        = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml
 INTEGRATIONS_DIR = /var/db/newrelic-infra/newrelic-integrations/
 CONFIG_DIR       = /etc/newrelic-infra/integrations.d


### PR DESCRIPTION
#### Description of the changes

This fixes a make failure caused by a lacking and non up to date tool dependency:
https://github.com/golang/lint/issues/415

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
