### PR TITLE
Allow old passwords

### DIFF
--- a/src/mysql.go
+++ b/src/mysql.go
@@ -23,10 +23,16 @@ type argumentList struct {
 	ExtendedMetrics       bool   `default:"false" help:"Enable extended metrics"`
 	ExtendedInnodbMetrics bool   `default:"false" help:"Enable InnoDB extended metrics"`
 	ExtendedMyIsamMetrics bool   `default:"false" help:"Enable MyISAM extended metrics"`
+	OldPasswords          bool   `default:"false" help:"Allow old passwords: https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_old_passwords"`
 }
 
 func generateDSN(args argumentList) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", args.Username, args.Password, args.Hostname, args.Port, args.Database)
+	params := ""
+	if args.OldPasswords {
+		params = "?allowOldPasswords=true"
+	}
+
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s%s", args.Username, args.Password, args.Hostname, args.Port, args.Database, params)
 }
 
 var args argumentList

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -181,3 +181,20 @@ func TestGenerateDSNPriorizesCliOverEnvArgs(t *testing.T) {
 
 	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
 }
+
+func TestGenerateDSNSupportsOldPasswords(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-hostname=dbhost",
+		"-username=dbuser",
+		"-password=dbpwd",
+		"-port=1234",
+		"-old_passwords",
+	}
+	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
+	fatalIfErr(err)
+
+	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?allowOldPasswords=true", generateDSN(args))
+
+	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
+}


### PR DESCRIPTION
#### Description of the changes

Allow old passwords.

When trying to run Mysql integration on a mysql-server with old password support https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_old_passwords integration won't run.

User will get an error like:

_this user requires old password authentication. If you still want to use it, please add 'allowOldPasswords=1' to your DSN. See also https://github.com/go-sql-driver/mysql/wiki/old_passwords_

This error message is shown when you are connecting to a MySQL database that has its passwords stored in the old password format ( http://dev.mysql.com/doc/refman/5.0/en/old-client.html ). Newer MySQL clients do not allow a connection to be made to databases using the old password format as it is less secure.

#### PR Review Checklist
### Author

- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
