### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.4.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-mysql to nri-mysql in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 1.3.0 (2019-04-29)
 ### Added
 - Upgraded to SDK v3.1.5. This version implements [the aget/integrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.9 as builder
-RUN go get -d github.com/newrelic/nri-mysql/... && \
-    cd /go/src/github.com/newrelic/nri-mysql && \
+COPY . /go/src/github.com/newrelic/nri-mysql/
+RUN cd /go/src/github.com/newrelic/nri-mysql && \
     make && \
-    strip ./bin/nr-mysql
+    strip ./bin/nri-mysql
 
 FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
-COPY --from=builder /go/src/github.com/newrelic/nri-mysql/bin/nr-mysql /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nr-mysql
+COPY --from=builder /go/src/github.com/newrelic/nri-mysql/bin/nri-mysql /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-mysql
 COPY --from=builder /go/src/github.com/newrelic/nri-mysql/mysql-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/definition.yaml
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INTEGRATION     := mysql
-BINARY_NAME      = nr-$(INTEGRATION)
+BINARY_NAME      = nri-$(INTEGRATION)
 SRC_DIR					 = ./src/
 VALIDATE_DEPS    = golang.org/x/lint/golint
 TEST_DEPS        = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost' WITH 
 ## Installation
 * download an archive file for the MySQL Integration
 * extract `mysql-definition.yml` and `/bin` directory into `/var/db/newrelic-infra/newrelic-integrations`
-* add execute permissions for the binary file `nr-mysql` (if required)
+* add execute permissions for the binary file `nri-mysql` (if required)
 * extract `mysql-config.yml.sample` into `/etc/newrelic-infra/integrations.d`
 
 ## Usage
@@ -35,13 +35,13 @@ Assuming that you have the source code and Go tool installed you can build and r
 ```bash
 $ make
 ```
-* The command above will execute the tests for the MySQL Integration and build an executable file called `nr-mysql` under `bin` directory. Run `nr-mysql` with parameters specifying username and password
+* The command above will execute the tests for the MySQL Integration and build an executable file called `nri-mysql` under `bin` directory. Run `nri-mysql` with parameters specifying username and password
 ```bash
-$ ./bin/nr-mysql -username <username> -password <password>
+$ ./bin/nri-mysql -username <username> -password <password>
 ```
-* If you want to know more about usage of `./bin/nr-mysql` check
+* If you want to know more about usage of `./bin/nri-mysql` check
 ```bash
-$ ./bin/nr-mysql -help
+$ ./bin/nri-mysql -help
 ```
 
 For managing external dependencies [govendor tool](https://github.com/kardianos/govendor) is used. It is required to lock all external dependencies to specific version (if possible) into vendor directory.

--- a/mysql-definition.yml
+++ b/mysql-definition.yml
@@ -6,6 +6,6 @@ os: linux
 commands:
     status:
         command:
-            - ./bin/nr-mysql
+            - ./bin/nri-mysql
         prefix: config/mysql
         interval: 30

--- a/src/mysql.go
+++ b/src/mysql.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	integrationName    = "com.newrelic.mysql"
-	integrationVersion = "1.2.0"
+	integrationVersion = "1.4.0"
 	nodeEntityType     = "node"
 )
 

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - nri-mysql
 
   nri-mysql:
+    container_name: integration_nri-mysql_1
     build:
       context: ../../
       dockerfile: tests/integration/Dockerfile

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -25,7 +25,7 @@ var (
 
 	defaultContainer = "integration_nri-mysql_1"
 	// mysql config
-	defaultBinPath   = "/nr-mysql"
+	defaultBinPath   = "/nri-mysql"
 	defaultMysqlUser = "root"
 	defaultMysqlPass = "DBpwd1234!"
 	defaultMysqlHost = "mysql"

--- a/tests/integration/json-schema-files/mysql-schema-inventory-master.json
+++ b/tests/integration/json-schema-files/mysql-schema-inventory-master.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/mysql-schema-master-localentity.json
+++ b/tests/integration/json-schema-files/mysql-schema-master-localentity.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/mysql-schema-master.json
+++ b/tests/integration/json-schema-files/mysql-schema-master.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/mysql-schema-metrics-master.json
+++ b/tests/integration/json-schema-files/mysql-schema-metrics-master.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.0$",
+      "pattern": "^1.4.0$",
       "type": "string"
     },
     "data": {


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-mysql to nri-mysql in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.