### PR TITLE
use latest 1.10 version to fix build (maybe?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10"
+  - "1.10.x"
 
 services:
   - docker


### PR DESCRIPTION
use latest 1.10 version as it seems some change in go tools broke golint 
More info: https://github.com/golang/lint/issues/402