### PR TITLE
fix rpm package name template

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -60,6 +60,7 @@ nfpms:
   
     overrides:
       rpm:
+        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Arch }}"
         replacements:
           amd64: 1.x86_64
 


### PR DESCRIPTION
For rpm packages, the package name if slightly different from deb packages so we have to use an override fopr the file_name_template