### PR TITLE
arvdias/add publishing action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,8 +11,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GO_VERSION: '1.9.7'
   INTEGRATION: "mysql"
-  ORIGINAL_REPO_NAME: 'newrelic/nri-mysql'
-  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+  ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
   TAG: ${{ github.event.release.tag_name }}
 
 jobs:
@@ -130,7 +129,7 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: prerelease pipeline failed."
 
   package-win:
     name: Create MSI & Upload into GH Release assets
@@ -173,7 +172,7 @@ jobs:
         with:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
+          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: prerelease pipeline failed."
 
   publish-to-s3:
     name: Send release assets to S3

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -110,11 +110,7 @@ jobs:
   prerelease:
     name: Build binary for *Nix/Win, create archives for *Nix/Win, create packages for *Nix, upload all artifacts into GH Release assets
     runs-on: ubuntu-20.04
-    needs: [validate, test-nix, test-windows, snyk, test-integration-nix]
-    env:
-      GPG_MAIL: 'infrastructure-eng@newrelic.com'
-      GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
-      GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
+    needs: [validate, snyk, test-nix, test-windows, test-integration-nix]
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub
@@ -124,6 +120,10 @@ jobs:
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Pre release
         run: make ci/prerelease
+        env:
+          GPG_MAIL: 'infrastructure-eng@newrelic.com'
+          GPG_PASSPHRASE: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY_BASE64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }} # base64 encoded
       - name: Notify failure via Slack
         if: ${{ failure() }}
         uses: archive/github-actions-slack@master
@@ -174,3 +174,40 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
           slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
           slack-text: "❌ `${{ env.REPO_FULL_NAME }}`: prerelease pipeline failed."
+
+  publish-to-s3:
+    name: Send release assets to S3
+    runs-on: ubuntu-20.04
+    needs: [package-win]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - name: Publish to S3 action
+        uses: newrelic/infrastructure-publish-action@main
+        env:
+          AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"
+        with:
+          disable_lock: false
+          run_id: ${{ github.run_id }}
+          env: pre-release
+          tag: ${{env.TAG}}
+          app_name: "nri-${{env.INTEGRATION}}"
+          repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          # 'ohi' is for integrations
+          schema: "ohi"
+          aws_region: "us-east-1"
+          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_STAGING }}
+          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_STAGING }}
+          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_STAGING }}
+          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+          # used for locking in case of concurrent releases
+          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          # used for signing package stuff
+          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+          

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -193,7 +193,6 @@ jobs:
         with:
           disable_lock: false
           run_id: ${{ github.run_id }}
-          env: pre-release
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -186,7 +186,7 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Publish to S3 action
-        uses: newrelic/infrastructure-publish-action@v1
+        uses: newrelic/infrastructure-publish-action@main
         env:
           AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
           AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -186,7 +186,7 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Publish to S3 action
-        uses: newrelic/infrastructure-publish-action@main
+        uses: newrelic/infrastructure-publish-action@v1
         env:
           AWS_S3_BUCKET_NAME: "nr-downloads-ohai-staging"
           AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock-staging"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,7 @@ env:
   GO_VERSION: '1.9.7'
   INTEGRATION: "mysql"
   ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
+  REPO_FULL_NAME: ${{ github.event.repository.full_name }}
   TAG: ${{ github.event.release.tag_name }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
           password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       - name: Publish to S3 action
-        uses: newrelic/infrastructure-publish-action@main
+        uses: newrelic/infrastructure-publish-action@v1
         env:
           AWS_S3_BUCKET_NAME: "nr-downloads-main"
           AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release pipeline
+
+on:
+  release:
+    types:
+      - released
+    tags:
+      - 'v*'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  INTEGRATION: "mysql"
+  ORIGINAL_REPO_NAME: 'newrelic/nri-mysql'
+  TAG: ${{ github.event.release.tag_name }}
+
+jobs:
+
+  publish-to-s3:
+    name: Send release assets to S3
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      - name: Publish to S3 action
+        uses: newrelic/infrastructure-publish-action@main
+        env:
+          AWS_S3_BUCKET_NAME: "nr-downloads-main"
+          AWS_S3_LOCK_BUCKET_NAME: "onhost-ci-lock"
+          AWS_REGION: "us-east-1"
+        with:
+          # lock enabled
+          disable_lock: false
+          run_id: ${{ github.run_id }}
+          env: release
+          tag: ${{env.TAG}}
+          app_name: "nri-${{env.INTEGRATION}}"
+          repo_name: ${{ env.ORIGINAL_REPO_NAME }}
+          # 'ohi' is for integrations
+          schema: "ohi"
+          aws_region: ${{ env.AWS_REGION }}
+          aws_role_arn: ${{ secrets.OHAI_AWS_ROLE_ARN_PRODUCTION }}
+          aws_role_session_name: ${{ secrets.OHAI_AWS_ROLE_SESSION_NAME_PRODUCTION }}
+          aws_access_key_id: ${{ secrets.OHAI_AWS_ACCESS_KEY_ID_PRODUCTION }}
+          aws_secret_access_key: ${{ secrets.OHAI_AWS_SECRET_ACCESS_KEY_PRODUCTION }}
+          aws_s3_bucket_name: ${{ env.AWS_S3_BUCKET_NAME }}
+          # used for locking in case of concurrent releases
+          aws_s3_lock_bucket_name: ${{ env.AWS_S3_LOCK_BUCKET_NAME }}
+          # used for signing package stuff
+          gpg_passphrase: ${{ secrets.OHAI_GPG_PASSPHRASE }}
+          gpg_private_key_base64: ${{ secrets.OHAI_GPG_PRIVATE_KEY_BASE64 }}
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           # lock enabled
           disable_lock: false
           run_id: ${{ github.run_id }}
-          env: release
           tag: ${{env.TAG}}
           app_name: "nri-${{env.INTEGRATION}}"
           repo_name: ${{ env.ORIGINAL_REPO_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   INTEGRATION: "mysql"
-  ORIGINAL_REPO_NAME: 'newrelic/nri-mysql'
+  ORIGINAL_REPO_NAME: ${{ github.event.repository.full_name }}
   TAG: ${{ github.event.release.tag_name }}
 
 jobs:

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -42,7 +42,8 @@ ci/snyk-test:
 			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e SNYK_TOKEN \
-			snyk/snyk:golang-1.15 snyk test --severity-threshold=high
+			-e GO111MODULE=auto \
+			snyk/snyk:golang snyk test --severity-threshold=high
 
 .PHONY : ci/build
 ci/build: ci/deps

--- a/build/ci.mk
+++ b/build/ci.mk
@@ -42,7 +42,7 @@ ci/snyk-test:
 			-v $(CURDIR):/go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-w /go/src/github.com/newrelic/nri-$(INTEGRATION) \
 			-e SNYK_TOKEN \
-			snyk/snyk:golang snyk test --severity-threshold=high
+			snyk/snyk:golang-1.15 snyk test --severity-threshold=high
 
 .PHONY : ci/build
 ci/build: ci/deps


### PR DESCRIPTION
This PR adds the "Publish to S3" job to the pre-release workflow.
It would be possible to use a distinct workflow and trigger it based on the success of the prerelease workflow, but we wouldn't have access to the TAG and a couple of other (minor) convenient env vars, which would mean we would have to add some extra code to check the tag we are publishing or have to change it manually, which is not ideal.

As such, the publishing step only is activated after the windows assets are uploaded, which are the last ones, and so we are guaranteed to have all the assets available to upload.