### PR TITLE
DB-3614: support passing optional parameters to the connection by usi…

### DIFF
--- a/src/mysql.go
+++ b/src/mysql.go
@@ -24,24 +24,24 @@ const (
 
 type argumentList struct {
 	sdk_args.DefaultArgumentList
-	Hostname              string `default:"localhost" help:"Hostname or IP where MySQL is running."`
-	Port                  int    `default:"3306" help:"Port on which MySQL server is listening."`
-	Username              string `help:"Username for accessing the database."`
-	Password              string `help:"Password for the given user."`
-	Database              string `help:"Database name"`
-	ConnectionParameters  string `help:"Specify connection parameters as attribute=value."` // https://github.com/go-sql-driver/mysql#parameters
-	RemoteMonitoring      bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true"`
-	ExtendedMetrics       bool   `default:"false" help:"Enable extended metrics"`
-	ExtendedInnodbMetrics bool   `default:"false" help:"Enable InnoDB extended metrics"`
-	ExtendedMyIsamMetrics bool   `default:"false" help:"Enable MyISAM extended metrics"`
-	OldPasswords          bool   `default:"false" help:"Allow old passwords: https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_old_passwords"`
-	ShowVersion           bool   `default:"false" help:"Print build information and exit"`
+	Hostname               string `default:"localhost" help:"Hostname or IP where MySQL is running."`
+	Port                   int    `default:"3306" help:"Port on which MySQL server is listening."`
+	Username               string `help:"Username for accessing the database."`
+	Password               string `help:"Password for the given user."`
+	Database               string `help:"Database name"`
+	ExtraConnectionURLArgs string `help:"Specify extra connection parameters as attribute=value."` // https://github.com/go-sql-driver/mysql#parameters
+	RemoteMonitoring       bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true"`
+	ExtendedMetrics        bool   `default:"false" help:"Enable extended metrics"`
+	ExtendedInnodbMetrics  bool   `default:"false" help:"Enable InnoDB extended metrics"`
+	ExtendedMyIsamMetrics  bool   `default:"false" help:"Enable MyISAM extended metrics"`
+	OldPasswords           bool   `default:"false" help:"Allow old passwords: https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_old_passwords"`
+	ShowVersion            bool   `default:"false" help:"Print build information and exit"`
 }
 
 func generateDSN(args argumentList) string {
-	params := args.ConnectionParameters
+	params := args.ExtraConnectionURLArgs
 	if args.OldPasswords {
-		params = strings.Join([]string{"allowOldPasswords=true", args.ConnectionParameters}, "&")
+		params = strings.Join([]string{"allowOldPasswords=true", args.ExtraConnectionURLArgs}, "&")
 	}
 	if params != "" {
 		params = "?" + strings.TrimSuffix(params, "&")

--- a/src/mysql.go
+++ b/src/mysql.go
@@ -29,7 +29,7 @@ type argumentList struct {
 	Username              string `help:"Username for accessing the database."`
 	Password              string `help:"Password for the given user."`
 	Database              string `help:"Database name"`
-	ConnectionParameters  string `help:"Specify connection parameters as attribute=value."`
+	ConnectionParameters  string `help:"Specify connection parameters as attribute=value."` // https://github.com/go-sql-driver/mysql#parameters
 	RemoteMonitoring      bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true"`
 	ExtendedMetrics       bool   `default:"false" help:"Enable extended metrics"`
 	ExtendedInnodbMetrics bool   `default:"false" help:"Enable InnoDB extended metrics"`
@@ -44,7 +44,7 @@ func generateDSN(args argumentList) string {
 		params = strings.Join([]string{"allowOldPasswords=true", args.ConnectionParameters}, "&")
 	}
 	if params != "" {
-		params = "?" + params
+		params = "?" + strings.TrimSuffix(params, "&")
 	}
 
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s%s", args.Username, args.Password, args.Hostname, args.Port, args.Database, params)

--- a/src/mysql.go
+++ b/src/mysql.go
@@ -29,6 +29,7 @@ type argumentList struct {
 	Username              string `help:"Username for accessing the database."`
 	Password              string `help:"Password for the given user."`
 	Database              string `help:"Database name"`
+	ConnectionParameters  string `help:"Specify connection parameters as attribute=value."`
 	RemoteMonitoring      bool   `default:"false" help:"Identifies the monitored entity as 'remote'. In doubt: set to true"`
 	ExtendedMetrics       bool   `default:"false" help:"Enable extended metrics"`
 	ExtendedInnodbMetrics bool   `default:"false" help:"Enable InnoDB extended metrics"`
@@ -38,9 +39,12 @@ type argumentList struct {
 }
 
 func generateDSN(args argumentList) string {
-	params := ""
+	params := args.ConnectionParameters
 	if args.OldPasswords {
-		params = "?allowOldPasswords=true"
+		params = strings.Join([]string{"allowOldPasswords=true", args.ConnectionParameters}, "&")
+	}
+	if params != "" {
+		params = "?" + params
 	}
 
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s%s", args.Username, args.Password, args.Hostname, args.Port, args.Database, params)

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -198,3 +198,20 @@ func TestGenerateDSNSupportsOldPasswords(t *testing.T) {
 
 	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
 }
+
+func TestGenerateDSNSupportsParameters(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-hostname=dbhost",
+		"-username=dbuser",
+		"-password=dbpwd",
+		"-port=1234",
+		"-connection_parameters=tls=skip-verify&timeout=5s",
+	}
+	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
+	fatalIfErr(err)
+
+	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?tls=skip-verify&timeout=5s", generateDSN(args))
+
+	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
+}

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -206,7 +206,7 @@ func TestGenerateDSNSupportsParameters(t *testing.T) {
 		"-username=dbuser",
 		"-password=dbpwd",
 		"-port=1234",
-		"-connection_parameters=tls=skip-verify&timeout=5s",
+		"-extra_connection_url_args=tls=skip-verify&timeout=5s",
 	}
 	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	fatalIfErr(err)

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -177,7 +177,7 @@ func TestGenerateDSNPriorizesCliOverEnvArgs(t *testing.T) {
 	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	fatalIfErr(err)
 
-	assert.Equal(t, "dbuser:dbpwd@tcp(bar:1234)/", generateDSN(args))
+	assert.Equal(t, "dbuser:dbpwd@tcp(bar:1234)/?", generateDSN(args))
 
 	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
 }
@@ -199,19 +199,53 @@ func TestGenerateDSNSupportsOldPasswords(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
 }
 
-func TestGenerateDSNSupportsParameters(t *testing.T) {
+func TestGenerateDSNSupportsEnableTLS(t *testing.T) {
 	os.Args = []string{
 		"cmd",
 		"-hostname=dbhost",
 		"-username=dbuser",
 		"-password=dbpwd",
 		"-port=1234",
-		"-extra_connection_url_args=tls=skip-verify&timeout=5s",
+		"-enable_tls",
 	}
 	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
 	fatalIfErr(err)
 
-	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?tls=skip-verify&timeout=5s", generateDSN(args))
+	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?tls=true", generateDSN(args))
+
+	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
+}
+
+func TestGenerateDSNSupportsInsecureSkipVerify(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-hostname=dbhost",
+		"-username=dbuser",
+		"-password=dbpwd",
+		"-port=1234",
+		"-insecure_skip_verify",
+	}
+	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
+	fatalIfErr(err)
+
+	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?tls=skip-verify", generateDSN(args))
+
+	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
+}
+
+func TestGenerateDSNSupportsExtraConnectionURLArgs(t *testing.T) {
+	os.Args = []string{
+		"cmd",
+		"-hostname=dbhost",
+		"-username=dbuser",
+		"-password=dbpwd",
+		"-port=1234",
+		"-extra_connection_url_args=readTimeout=1s&timeout=5s&tls=skip-verify",
+	}
+	_, err := integration.New(integrationName, integrationVersion, integration.Args(&args))
+	fatalIfErr(err)
+
+	assert.Equal(t, "dbuser:dbpwd@tcp(dbhost:1234)/?readTimeout=1s&timeout=5s&tls=skip-verify", generateDSN(args))
 
 	flag.CommandLine = flag.NewFlagSet("cmd", flag.ContinueOnError)
 }


### PR DESCRIPTION
…ng flag -extra_connection_url_args tls=skip-verify&timeout=5s

Hi 👋, we require TLS support for all database connections in AWS, so I'm making a quick change to support passing in optional connection parameters to the Go MySQL driver. Please see https://github.com/go-sql-driver/mysql#parameters for more info on the supported connection parameters. 


Example Invocation using the -extra_connection_url_args to use a TLS connection, but not verify the certificate and set a timeout for it:
```
./nri-mysql -hostname db-depot.cluster-cl3aokvievxs.us-east-2.rds.amazonaws.com -database db_depot -port 3306 -username $u -password $p -extra_connection_url_args "tls=skip-verify&timeout=5s"
```

This should address a recent issue https://github.com/newrelic/nri-mysql/issues/87 too.

For instance, to support encryption on an RDS instance and verify the certificate we will need to import their bundle first. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html for further information and link to download their bundle.

I'm using an alpine container here with newrelic-infra running in it:
```
/ # cat /etc/os-release
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.8.4
PRETTY_NAME="Alpine Linux v3.8"
HOME_URL="http://alpinelinux.org"
BUG_REPORT_URL="http://bugs.alpinelinux.org"
```

Here's a failure case using nri-mysql that includes `tls=true` to verify the certificate used for the TLS connection. It fails since we do not have the certificate imported into the standard system CA locations the Go x509 package searches by default:
```
/ # ./nri-mysql hostname db-depot.cluster-cl3aokvievxs.us-east-2.rds.amazonaws.com -database db_depot -port 3306 -username $u -password $p -extra_connection_url_args "tls=true&timeout=5s"
[FATAL] can't continue: error querying inventory: error executing `SHOW GLOBAL VARIABLES`: x509: certificate signed by unknown authority
```

This alpine image has ca-certificates already installed, so we can download the AWS global bundle, place in the proper location and run update-ca-certificates:
```
/ # wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
Connecting to truststore.pki.rds.amazonaws.com (52.84.145.100:443)
global-bundle.pem    100% |***********************************************************************************************************************************************************************************************|   146k  0:00:00 ETA
/ # mv global-bundle.pem /usr/local/share/ca-certificates/
/ # update-ca-certificates
```

re-running nri-mysql test case and printing first 128 bytes:
```
/ # ./nri-mysql -hostname db-depot.cluster-cl3aokvievxs.us-east-2.rds.amazonaws.com -database db_depot -port 3306 -username $u -password $p -extra_connection_url_args "tls=true&timeout=5s" | head -c 128; echo
{"name":"com.newrelic.mysql","protocol_version":"3","integration_version":"0.0.0","data":[{"metrics":[{"cluster.nodeType":"maste
```

Note: updated examples to reflect flag name change to extra_connection_url_args after pushing change.
