### PR TITLE
Updated goreleaser for mysql-log.yml

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -50,7 +50,7 @@ nfpms:
       - src: "mysql-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/mysql-config.yml.sample"
       - src: "mysql-log.yml.sample"
-        dst: "/etc/newrelic-infra/integrations.d/mysql-log.yml.sample"
+        dst: "/etc/newrelic-infra/logging.d/mysql-log.yml.sample"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-mysql/CHANGELOG.md"
       - src: "README.md"

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -49,6 +49,8 @@ nfpms:
     contents:
       - src: "mysql-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/mysql-config.yml.sample"
+      - src: "mysql-log.yml.sample"
+        dst: "/etc/newrelic-infra/integrations.d/mysql-log.yml.sample"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-mysql/CHANGELOG.md"
       - src: "README.md"

--- a/mysql-log.yml.sample
+++ b/mysql-log.yml.sample
@@ -1,0 +1,7 @@
+logs:
+# This sample file will forward mysql error logs to NR once it's renamed to mysql-log.yml
+# On Linux systems no restart is needed
+  - name: "mysqllog"
+    file: /var/log/mysql/error.log
+    attributes:
+      logtype: mysql-error


### PR DESCRIPTION
Updated the goreleaser file to include the new mysql-log.yml.sample file. This new .sample file will allow users to automatically send mysql logs to NR, properly formattted, just by renaming this file to .yml.