### PR TITLE
[NR-286408] chore: update docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ test:
 
 integration-test:
 	@echo "=== $(INTEGRATION) === [ test ]: running integration tests..."
-	@docker-compose -f tests/integration/docker-compose.yml up -d --build
-	@go test -tags=integration ./tests/integration/. || (ret=$$?; docker-compose -f tests/integration/docker-compose.yml down && exit $$ret)
-	@docker-compose -f tests/integration/docker-compose.yml down
+	@docker compose -f tests/integration/docker-compose.yml up -d --build
+	@go test -tags=integration ./tests/integration/. || (ret=$$?; docker compose -f tests/integration/docker-compose.yml down && exit $$ret)
+	@docker compose -f tests/integration/docker-compose.yml down
 
 install: bin/$(BINARY_NAME)
 	@echo "=== $(INTEGRATION) === [ install ]: installing bin/$(BINARY_NAME)..."


### PR DESCRIPTION
`docker-compose` v1 is EOL, and we need to move to `docker compose` (wit a space).