### PR TITLE
feat: Added Query Performance Monitoring support for aurora mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### enhancements
+- Added Query Performance Monitoring support for Aurora Mysql
+
 ## v1.13.0 - 2025-02-05
 
 ### 🚀 Enhancements

--- a/src/query-performance-monitoring/utils/queries.go
+++ b/src/query-performance-monitoring/utils/queries.go
@@ -43,8 +43,6 @@ const (
 		WHERE LAST_SEEN >= UTC_TIMESTAMP() - INTERVAL ? SECOND
 			AND SCHEMA_NAME IS NOT NULL
 			AND SCHEMA_NAME NOT IN (?)
-			AND DIGEST_TEXT RLIKE '^(SELECT|INSERT|UPDATE|DELETE|WITH)'
-			AND DIGEST_TEXT NOT LIKE '%DIGEST_TEXT%'
 		ORDER BY avg_elapsed_time_ms DESC
 		LIMIT ?;
     `
@@ -187,7 +185,6 @@ const (
 				performance_schema.events_statements_current s
 			WHERE
 				s.CURRENT_SCHEMA NOT IN (?)
-				AND s.SQL_TEXT NOT LIKE '%DIGEST_TEXT%'
 			UNION ALL
 			SELECT
 				s.THREAD_ID,
@@ -198,7 +195,6 @@ const (
 				performance_schema.events_statements_history s
 			WHERE
 				s.CURRENT_SCHEMA NOT IN (?)
-				AND s.SQL_TEXT NOT LIKE '%DIGEST_TEXT%'
 		),
 		joined_data AS (
 			SELECT

--- a/src/query-performance-monitoring/validator/validations.go
+++ b/src/query-performance-monitoring/validator/validations.go
@@ -14,6 +14,9 @@ import (
 // Query to check if the Performance Schema is enabled
 const performanceSchemaQuery = "SHOW GLOBAL VARIABLES LIKE 'performance_schema';"
 
+// Query to get the MySQL version
+const versionQuery = "SELECT VERSION();"
+
 // Dynamic error
 var (
 	ErrImproperlyFormattedVersion = errors.New("version string is improperly formatted")
@@ -52,13 +55,13 @@ func ValidatePreconditions(db utils.DataSource) error {
 	// Check if essential consumers are enabled
 	errEssentialConsumers := checkEssentialConsumers(db)
 	if errEssentialConsumers != nil {
-		return fmt.Errorf("essential consumer check failed: %w", errEssentialConsumers)
+		log.Warn("Essential consumer check failed: %v", errEssentialConsumers)
 	}
 
 	// Check if essential instruments are enabled
 	errEssentialInstruments := checkEssentialInstruments(db)
 	if errEssentialInstruments != nil {
-		return fmt.Errorf("essential instruments check failed: %w", errEssentialInstruments)
+		log.Warn("Essential instruments check failed: %v", errEssentialInstruments)
 	}
 	return nil
 }
@@ -104,7 +107,7 @@ func checkEssentialStatus(db utils.DataSource, query string, updateSQLTemplate s
 			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		if enabled != "YES" {
-			log.Error(updateSQLTemplate, name, name)
+			log.Warn(updateSQLTemplate, name, name)
 			return fmt.Errorf("%w: %s", errMsgTemplate, name)
 		}
 	}
@@ -142,8 +145,7 @@ func logEnablePerformanceSchemaInstructions(version string) {
 
 // getMySQLVersion retrieves the MySQL version from the database.
 func getMySQLVersion(db utils.DataSource) (string, error) {
-	query := "SELECT VERSION();"
-	rows, err := db.QueryX(query)
+	rows, err := db.QueryX(versionQuery)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute version query: %w", err)
 	}


### PR DESCRIPTION
For the standard MySQL integration, we ensure that the performance schema, along with essential consumers and instruments, is enabled. However, with Aurora MySQL, some consumers are missing, so we have eliminated the mandatory check for these essential consumers and instruments. In the standard MySQL integration, enabling the performance schema, essential consumers, and instruments is an integral part of the installation process.