### PR TITLE
fix: revert to use old replicaQuery for mariadb server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### bugfix
+- revert to use old replicaQuery for mariadb server
+
 ## v1.14.1 - 2025-03-24
 
 ### ⛓️ Dependencies

--- a/src/metrics_parse_test.go
+++ b/src/metrics_parse_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +23,32 @@ func TestIsDBVersionLessThan8(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.dbVersion, func(t *testing.T) {
 			actual := isDBVersionLessThan8(test.dbVersion)
+			assert.Equal(t, test.expected, actual)
+			if actual != test.expected {
+				assert.Equal(t, test.expected, actual, "For version %s, expected %v, but got %v", test.dbVersion, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsDBVersionLessThan8Point4(t *testing.T) {
+	tests := []struct {
+		dbVersion string
+		expected  bool
+	}{
+		{"5.7.0", true},
+		{"8.0.0", true},
+		{"8.4.0", false},
+		{"9.1.0", false},
+		{"07.5", true},
+		{"18.5.2", false},
+		{"invalid_major_version.2.1", true},
+		{"10.invalid_minor_version.1", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.dbVersion, func(t *testing.T) {
+			actual := isDBVersionLessThan8Point4(test.dbVersion)
 			assert.Equal(t, test.expected, actual)
 			if actual != test.expected {
 				assert.Equal(t, test.expected, actual, "For version %s, expected %v, but got %v", test.dbVersion, test.expected, actual)
@@ -69,7 +97,7 @@ func TestExtractSanitizedVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.version, func(t *testing.T) {
-			actual, err := extractSanitizedVersion(test.version)
+			actual, err := extractSanitizedDBVersion(test.version)
 			if (err == nil) && (!test.shouldFail) {
 				assert.Equal(t, test.expected, actual)
 			} else if actual != test.expected {
@@ -104,5 +132,135 @@ func TestGetRawDataWithoutDBVersion(t *testing.T) {
 	}
 	if dbVersion == "" {
 		t.Error()
+	}
+}
+
+func TestIsMariaDBServer(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected bool
+	}{
+		{"8.4.3-standard", false},
+		{"8.0.40-0ubuntu0.22.04.1", false},
+		{"", false},
+		{"invalid", false},
+		{"11.3.2-MariaDB-log", true},
+		{"5.6.7-MARIA-DB", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			actual := isMariaDBServer(test.version)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetRawDBVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockRows      *sqlmock.Rows
+		expected      string
+		shouldFail    bool
+		expectedError error
+	}{
+		{
+			name:          "Successful dbVersion query",
+			mockRows:      sqlmock.NewRows([]string{"version"}).AddRow("8.0.40-0ubuntu0.22.04.1"),
+			expected:      "8.0.40-0ubuntu0.22.04.1",
+			shouldFail:    false,
+			expectedError: nil,
+		},
+		{
+			name:          "Error exec dbVersion query",
+			mockRows:      nil,
+			expected:      "",
+			shouldFail:    true,
+			expectedError: fmt.Errorf("error fetching dbVersion: %w", assert.AnError),
+		},
+		{
+			name:          "Version not found in result",
+			mockRows:      sqlmock.NewRows([]string{""}).AddRow(nil),
+			expected:      "",
+			shouldFail:    true,
+			expectedError: fmt.Errorf("%w", errVersionNotFound),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			assert.NoError(t, err)
+			defer db.Close()
+
+			assert.NoError(t, err)
+			database := &database{source: db}
+
+			if test.mockRows == nil && test.shouldFail {
+				mock.ExpectQuery(dbVersionQuery).WillReturnError(assert.AnError)
+			} else {
+				mock.ExpectQuery(dbVersionQuery).WillReturnRows(test.mockRows)
+			}
+
+			actual, err := getRawDBVersion(database)
+			if test.shouldFail {
+				assert.Error(t, test.expectedError, err)
+			} else {
+				assert.Equal(t, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCheckDBServerAndGetDBVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		mockRows *sqlmock.Rows
+		expected string
+	}{
+		{
+			name:     "Successful dbVersion query",
+			mockRows: sqlmock.NewRows([]string{"version"}).AddRow("8.0.40-0ubuntu0.22.04.1"),
+			expected: "8.0.40",
+		},
+		{
+			name:     "dbVersion query output with mariadb",
+			mockRows: sqlmock.NewRows([]string{"version"}).AddRow("11.3.2-MariaDB-log"),
+			expected: "5.7.0",
+		},
+		{
+			name:     "Error exec dbVersion query",
+			mockRows: nil,
+			expected: "5.7.0",
+		},
+		{
+			name:     "Version not found in result",
+			mockRows: sqlmock.NewRows([]string{""}).AddRow(nil),
+			expected: "5.7.0",
+		},
+		{
+			name:     "Invalid dbVersion output",
+			mockRows: sqlmock.NewRows([]string{"version"}).AddRow("invalid"),
+			expected: "5.7.0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			assert.NoError(t, err)
+			defer db.Close()
+
+			assert.NoError(t, err)
+			database := &database{source: db}
+			if test.mockRows != nil {
+				mock.ExpectQuery(dbVersionQuery).WillReturnRows(test.mockRows)
+			} else {
+				mock.ExpectQuery(dbVersionQuery).WillReturnError(assert.AnError)
+			}
+
+			actual := checkDBServerAndGetDBVersion(database)
+			assert.Equal(t, test.expected, actual)
+		})
 	}
 }


### PR DESCRIPTION
Issue - Version check was introduced in release v1.12.0 to make `nri-mysql` compatible with mysql 8.40 and above. Due to this the replica metrics for mariadb server are not getting populated.

Fix - After getting the raw version string from DB server added a check to verify if the server is MariaDB. If the server is MariaDB then we are using the older replicaQuery to fetch the replica metrics.

Testing - Added unit tests. Integration tests will be added later as part of this [Jira](https://new-relic.atlassian.net/browse/NR-381562). For more test details refer [here](https://new-relic.atlassian.net/browse/NR-380438?focusedCommentId=1172745)