### PR TITLE
Reverted Changelog back to changes from v1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### dependencies
-- Updated github.com/go-sql-driver/mysql to v1.9.2
+### enhancement
+- Updated github.com/go-sql-driver/mysql to v1.9.2 - [Changelog 🔗](https://github.com/go-sql-driver/mysql/releases/tag/v1.9.2)
 
 ## v1.14.2 - 2025-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-## v1.14.3 - 2025-04-14
-
-### ⛓️ Dependencies
+### dependencies
 - Updated github.com/go-sql-driver/mysql to v1.9.2 - [Changelog 🔗](https://github.com/go-sql-driver/mysql/releases/tag/v1.9.2)
 
 ## v1.14.2 - 2025-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### dependencies
-- Updated github.com/go-sql-driver/mysql to v1.9.2 - [Changelog 🔗](https://github.com/go-sql-driver/mysql/releases/tag/v1.9.2)
+- Updated github.com/go-sql-driver/mysql to v1.9.2
 
 ## v1.14.2 - 2025-03-31
 


### PR DESCRIPTION
Prerelease was lost when buckets were synced and the staging bucker was restored.