### PR TITLE
Implemented backup metrics for the MariaDB and MySQL integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### 🚀 Enhancements
+- Added MariaDB/MySQL backup metrics support via `EXTENDED_BACKUP_METRICS` and `EXTENDED_BACKUP_HISTORY_METRICS` flags, reporting active backup operations (`db.backupActive.*`) and historical backup statistics (`db.backupHistory.*`).
+
 ## v1.22.0 - 2026-05-15
 
 ### 🛡️ Security notices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### 🚀 Enhancements
+### Enhancements
 - Added MariaDB/MySQL backup metrics support via `EXTENDED_BACKUP_METRICS` and `EXTENDED_BACKUP_HISTORY_METRICS` flags, reporting active backup operations (`db.backupActive.*`) and historical backup statistics (`db.backupHistory.*`).
 
 ## v1.22.0 - 2026-05-15

--- a/mysql-config.yml.sample
+++ b/mysql-config.yml.sample
@@ -25,6 +25,8 @@ integrations:
     # Enable additional metrics
     # EXTENDED_INNODB_METRICS: false
     # EXTENDED_MY_ISAM_METRICS: false
+    # EXTENDED_BACKUP_METRICS: false
+    # EXTENDED_BACKUP_HISTORY_METRICS: false
 
     # New users should leave this property as `true`, to identify the
     # monitored entities as `remote`. Setting this property to `false` (the

--- a/src/args/argument_list.go
+++ b/src/args/argument_list.go
@@ -17,6 +17,8 @@ type ArgumentList struct {
 	ExtendedMetrics                      bool   `default:"false" help:"Enable collection of extended metrics."`
 	ExtendedInnodbMetrics                bool   `default:"false" help:"Enable collection of extended InnoDB metrics."`
 	ExtendedMyIsamMetrics                bool   `default:"false" help:"Enable collection of extended MyISAM metrics."`
+	ExtendedBackupMetrics                bool   `default:"false" help:"Enable collection of active backup operation metrics."`
+	ExtendedBackupHistoryMetrics         bool   `default:"false" help:"Enable collection of historical backup metrics from performance_schema."`
 	OldPasswords                         bool   `default:"false" help:"Allow the use of old passwords: https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_old_passwords"`
 	ShowVersion                          bool   `default:"false" help:"Display build information and exit."`
 	EnableQueryMonitoring                bool   `default:"false" help:"Enable collection of detailed query performance metrics."`

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"database/sql"
 	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+	"github.com/newrelic/infra-integrations-sdk/v3/log"
 )
 
 // backupMetrics defines metrics for detecting active backup operations
@@ -15,19 +17,16 @@ var backupMetrics = map[string][]interface{}{
 
 // backupHistoryMetrics defines metrics for historical backup operations from performance_schema
 var backupHistoryMetrics = map[string][]interface{}{
-	"db.backupHistory.total":                {"total_backup_history", metric.GAUGE},
-	"db.backupHistory.logical.count":        {"logical_backup_count", metric.GAUGE},
-	"db.backupHistory.logical.avgDuration":  {"logical_backup_avg_duration", metric.GAUGE},
-	"db.backupHistory.logical.maxDuration":  {"logical_backup_max_duration", metric.GAUGE},
-	"db.backupHistory.physical.count":       {"physical_backup_count", metric.GAUGE},
-	"db.backupHistory.physical.avgDuration": {"physical_backup_avg_duration", metric.GAUGE},
-	"db.backupHistory.physical.maxDuration": {"physical_backup_max_duration", metric.GAUGE},
-	"db.backupHistory.tableLock.count":      {"table_lock_count", metric.GAUGE},
+	"db.backupHistory.total":                 {"total_backup_history", metric.GAUGE},
+	"db.backupHistory.logical.count":         {"logical_backup_count", metric.GAUGE},
+	"db.backupHistory.logical.avgDuration":   {"logical_backup_avg_duration", metric.GAUGE},
+	"db.backupHistory.logical.maxDuration":   {"logical_backup_max_duration", metric.GAUGE},
+	"db.backupHistory.physical.count":        {"physical_backup_count", metric.GAUGE},
+	"db.backupHistory.physical.avgDuration":  {"physical_backup_avg_duration", metric.GAUGE},
+	"db.backupHistory.physical.maxDuration":  {"physical_backup_max_duration", metric.GAUGE},
+	"db.backupHistory.tableLock.count":       {"table_lock_count", metric.GAUGE},
 	"db.backupHistory.tableLock.avgDuration": {"table_lock_avg_duration", metric.GAUGE},
 	"db.backupHistory.tableLock.maxDuration": {"table_lock_max_duration", metric.GAUGE},
-	"db.backupHistory.other.count":          {"other_backup_count", metric.GAUGE},
-	"db.backupHistory.other.avgDuration":    {"other_backup_avg_duration", metric.GAUGE},
-	"db.backupHistory.other.maxDuration":    {"other_backup_max_duration", metric.GAUGE},
 }
 
 // backupMetricsQuery detects active backup operations using performance_schema.metadata_locks
@@ -37,23 +36,36 @@ var backupHistoryMetrics = map[string][]interface{}{
 // MariaDB-specific implementation using metadata_locks table with OWNER_THREAD_ID
 //
 // Detection methods:
-// - Physical Backup: FLUSH TABLES WITH READ LOCK creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
-// - Table Lock: LOCK TABLES creates SHARED_READ/SHARED_WRITE locks on user tables
-//   Note: MariaDB uses LOCK_DURATION='TRANSACTION' for LOCK TABLES (not 'EXPLICIT')
-//   We detect sessions holding explicit table locks as indicator of LOCK TABLES usage
-// - Logical Backup: Long-running read-only transactions (e.g., START TRANSACTION WITH CONSISTENT SNAPSHOT)
-//   Detected via information_schema.innodb_trx looking for transactions that:
-//   * Are in RUNNING state
-//   * Have not modified any rows (trx_rows_modified = 0)
-//   * Have been running for at least 2 seconds
+//
+//   - Physical Backup: FLUSH TABLES WITH READ LOCK creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
+//
+//   - Table Lock: LOCK TABLES creates SHARED_READ/SHARED_WRITE locks on user tables
+//     Note: MariaDB uses LOCK_DURATION='TRANSACTION' for LOCK TABLES (not 'EXPLICIT')
+//     We detect sessions holding explicit table locks as indicator of LOCK TABLES usage
+//
+//   - Logical Backup: Long-running read-only transactions (e.g., START TRANSACTION WITH CONSISTENT SNAPSHOT)
+//     Detected via information_schema.innodb_trx looking for transactions that:
+//
+//   - Are in RUNNING state
+//
+//   - Have not modified any rows (trx_rows_modified = 0)
+//
+//   - Have been running for at least 30 seconds (reduces false positives from long SELECT queries)
+//
+//     NOTE: This heuristic may still catch some false positives (long reports, analytics queries).
+//     To reduce false positives further, you can:
+//
+//   - Increase the threshold (30s default is conservative for most backup tools)
+//
+//   - Exclude specific users by filtering on trx_mysql_thread_id
 //
 // Note: This query is optimized for MariaDB 10.5+. For MySQL 8.0+, use PROCESSLIST_ID instead of OWNER_THREAD_ID
 const backupMetricsQuery = `
 SELECT
-    COALESCE(physical_backup_active, 0) + COALESCE(table_lock_active, 0) + COALESCE(logical_backup_active, 0) AS total_backup_active,
-    COALESCE(logical_backup_active, 0) AS logical_backup_active,
-    COALESCE(physical_backup_active, 0) AS physical_backup_active,
-    COALESCE(table_lock_active, 0) AS table_lock_active,
+    COALESCE(b.physical_backup_active, 0) + COALESCE(b.table_lock_active, 0) + COALESCE(l.logical_backup_active, 0) AS total_backup_active,
+    COALESCE(l.logical_backup_active, 0) AS logical_backup_active,
+    COALESCE(b.physical_backup_active, 0) AS physical_backup_active,
+    COALESCE(b.table_lock_active, 0) AS table_lock_active,
     0 AS other_backup_active
 FROM (
     SELECT
@@ -77,17 +89,18 @@ FROM (
         END) AS table_lock_active
     FROM performance_schema.metadata_locks
     WHERE OWNER_THREAD_ID IS NOT NULL
-) backup_summary
-CROSS JOIN (
+) b,
+(
     SELECT
         -- Logical backups: Long-running read-only transactions
         -- Typical pattern: START TRANSACTION WITH CONSISTENT SNAPSHOT followed by data reads
+        -- Using 30-second threshold to reduce false positives from regular queries
         COUNT(DISTINCT trx_id) AS logical_backup_active
     FROM information_schema.innodb_trx
     WHERE trx_state = 'RUNNING'
         AND trx_rows_modified = 0
-        AND TIMESTAMPDIFF(SECOND, trx_started, NOW()) >= 2
-) logical_backups
+        AND TIMESTAMPDIFF(SECOND, trx_started, NOW()) >= 30
+) l
 `
 
 // backupHistoryMetricsQuery analyzes historical backup operations from performance_schema
@@ -96,10 +109,14 @@ CROSS JOIN (
 // - Logical Backup: mysqldump using START TRANSACTION WITH CONSISTENT SNAPSHOT
 // - Physical Backup: Physical backups using FLUSH TABLES WITH READ LOCK
 // - Table Lock: Table-level locks using LOCK TABLES
-// - Other: Other backup-related activities
+//
+// Note: events_statements_history is a ring buffer with limited size (typically 10 events per thread)
+// Older events may have been evicted, so this represents recent history only
 const backupHistoryMetricsQuery = `
 SELECT
-    COUNT(*) AS total_backup_history,
+    COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END), 0)
+    + COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END), 0)
+    + COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END), 0) AS total_backup_history,
     SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END) AS logical_backup_count,
     AVG(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_avg_duration,
     MAX(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_max_duration,
@@ -108,27 +125,77 @@ SELECT
     MAX(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS physical_backup_max_duration,
     SUM(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END) AS table_lock_count,
     AVG(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_avg_duration,
-    MAX(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_max_duration,
-    SUM(CASE
-        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
-        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
-        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN 1
-        ELSE 0
-    END) AS other_backup_count,
-    AVG(CASE
-        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
-        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
-        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000
-        ELSE NULL
-    END) AS other_backup_avg_duration,
-    MAX(CASE
-        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
-        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
-        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000
-        ELSE NULL
-    END) AS other_backup_max_duration
+    MAX(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_max_duration
 FROM performance_schema.events_statements_history
 WHERE (SQL_TEXT LIKE '%LOCK TABLES%'
-    OR SQL_TEXT LIKE '%FLUSH%'
+    OR SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%'
     OR SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
 `
+
+// backupMetricsQueryFallback is for older versions (MySQL 5.7, MariaDB < 10.5)
+// that don't have performance_schema.metadata_locks table
+// This uses information_schema.processlist which is less accurate but universally available
+//
+// Limitations:
+// - Can only detect backups currently executing LOCK/FLUSH statements
+// - Cannot detect held locks (once statement completes, lock disappears from processlist)
+// - Less reliable than metadata_locks approach
+const backupMetricsQueryFallback = `
+SELECT
+    COALESCE(p.table_lock_active, 0) + COALESCE(t.logical_backup_active, 0) AS total_backup_active,
+    COALESCE(t.logical_backup_active, 0) AS logical_backup_active,
+    0 AS physical_backup_active,
+    COALESCE(p.table_lock_active, 0) AS table_lock_active,
+    0 AS other_backup_active
+FROM (
+    SELECT
+        -- Table locks: Sessions executing LOCK TABLES statements
+        COUNT(DISTINCT CASE
+            WHEN INFO LIKE '%LOCK TABLES%'
+                AND COMMAND != 'Sleep'
+            THEN ID
+        END) AS table_lock_active
+    FROM information_schema.processlist
+    WHERE ID IS NOT NULL
+) p,
+(
+    SELECT
+        -- Logical backups: Long-running read-only transactions (InnoDB only)
+        -- Uses same heuristic as main query (30+ seconds, no modifications)
+        COUNT(DISTINCT trx_id) AS logical_backup_active
+    FROM information_schema.innodb_trx
+    WHERE trx_state = 'RUNNING'
+        AND trx_rows_modified = 0
+        AND TIMESTAMPDIFF(SECOND, trx_started, NOW()) >= 30
+) t
+`
+
+// supportsMetadataLocks checks if the database supports performance_schema.metadata_locks
+// Returns true for MySQL 8.0+ and MariaDB 10.5+
+func supportsMetadataLocks(db *sql.DB) bool {
+	var count int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = 'performance_schema'
+		  AND TABLE_NAME = 'metadata_locks'
+	`).Scan(&count)
+
+	if err != nil {
+		log.Warn("Failed to check for metadata_locks table: %v", err)
+		return false
+	}
+
+	return count > 0
+}
+
+// getBackupMetricsQuery returns the appropriate backup metrics query based on database version
+func getBackupMetricsQuery(db *sql.DB) string {
+	if supportsMetadataLocks(db) {
+		log.Debug("Using metadata_locks-based backup detection (MySQL 8.0+/MariaDB 10.5+)")
+		return backupMetricsQuery
+	}
+
+	log.Info("metadata_locks table not available, using fallback query (MySQL 5.7/MariaDB < 10.5)")
+	return backupMetricsQueryFallback
+}

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -12,7 +12,6 @@ var backupMetrics = map[string][]interface{}{
 	"db.backupActive.logical":   {"logical_backup_active", metric.GAUGE},
 	"db.backupActive.physical":  {"physical_backup_active", metric.GAUGE},
 	"db.backupActive.tableLock": {"table_lock_active", metric.GAUGE},
-	"db.backupActive.other":     {"other_backup_active", metric.GAUGE},
 }
 
 // backupHistoryMetrics defines metrics for historical backup operations from performance_schema
@@ -59,14 +58,12 @@ var backupHistoryMetrics = map[string][]interface{}{
 //
 //   - Exclude specific users by filtering on trx_mysql_thread_id
 //
-// Note: This query is optimized for MariaDB 10.5+. For MySQL 8.0+, use PROCESSLIST_ID instead of OWNER_THREAD_ID
 const backupMetricsQuery = `
 SELECT
     COALESCE(b.physical_backup_active, 0) + COALESCE(b.table_lock_active, 0) + COALESCE(l.logical_backup_active, 0) AS total_backup_active,
     COALESCE(l.logical_backup_active, 0) AS logical_backup_active,
     COALESCE(b.physical_backup_active, 0) AS physical_backup_active,
-    COALESCE(b.table_lock_active, 0) AS table_lock_active,
-    0 AS other_backup_active
+    COALESCE(b.table_lock_active, 0) AS table_lock_active
 FROM (
     SELECT
         -- Physical backups: FLUSH TABLES WITH READ LOCK (MariaBackup, Percona XtraBackup)
@@ -77,14 +74,18 @@ FROM (
                 AND LOCK_STATUS = 'GRANTED'
             THEN OWNER_THREAD_ID
         END) AS physical_backup_active,
-        -- Table locks: LOCK TABLES ... READ/WRITE
-        -- Creates SHARED_READ or SHARED_WRITE locks on user tables
-        -- Includes locks on mysql.* schema as these are common in backup operations
+        -- Table locks: LOCK TABLES ... READ/WRITE (mysqldump --lock-tables, write-lock backups)
+        -- SHARED_READ: read locks (LOCK TABLES t READ)
+        -- SHARED_NO_READ_WRITE/EXCLUSIVE: write locks (LOCK TABLES t WRITE)
+        -- LOCK_DURATION IN ('EXPLICIT', 'TRANSACTION') covers both engines:
+        --   MySQL:   LOCK TABLES creates EXPLICIT duration locks
+        --   MariaDB: LOCK TABLES creates TRANSACTION duration locks
         COUNT(DISTINCT CASE
             WHEN OBJECT_TYPE = 'TABLE'
-                AND LOCK_TYPE IN ('SHARED_READ', 'SHARED_WRITE', 'SHARED_NO_READ_WRITE', 'EXCLUSIVE')
+                AND LOCK_TYPE IN ('SHARED_READ', 'SHARED_NO_READ_WRITE', 'EXCLUSIVE')
                 AND LOCK_STATUS = 'GRANTED'
-                AND OBJECT_SCHEMA NOT IN ('performance_schema', 'information_schema')
+                AND LOCK_DURATION IN ('EXPLICIT', 'TRANSACTION')
+                AND OBJECT_SCHEMA NOT IN ('performance_schema', 'information_schema', 'sys')
             THEN OWNER_THREAD_ID
         END) AS table_lock_active
     FROM performance_schema.metadata_locks
@@ -116,18 +117,18 @@ const backupHistoryMetricsQuery = `
 SELECT
     COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END), 0)
     + COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END), 0)
-    + COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END), 0) AS total_backup_history,
-    SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END) AS logical_backup_count,
-    AVG(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_avg_duration,
-    MAX(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_max_duration,
-    SUM(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END) AS physical_backup_count,
-    AVG(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS physical_backup_avg_duration,
-    MAX(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS physical_backup_max_duration,
-    SUM(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END) AS table_lock_count,
-    AVG(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_avg_duration,
-    MAX(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_max_duration
+    + COALESCE(SUM(CASE WHEN SQL_TEXT LIKE 'LOCK TABLES %' THEN 1 ELSE 0 END), 0) AS total_backup_history,
+    COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END), 0) AS logical_backup_count,
+    COALESCE(AVG(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS logical_backup_avg_duration,
+    COALESCE(MAX(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS logical_backup_max_duration,
+    COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END), 0) AS physical_backup_count,
+    COALESCE(AVG(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS physical_backup_avg_duration,
+    COALESCE(MAX(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS physical_backup_max_duration,
+    COALESCE(SUM(CASE WHEN SQL_TEXT LIKE 'LOCK TABLES %' THEN 1 ELSE 0 END), 0) AS table_lock_count,
+    COALESCE(AVG(CASE WHEN SQL_TEXT LIKE 'LOCK TABLES %' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS table_lock_avg_duration,
+    COALESCE(MAX(CASE WHEN SQL_TEXT LIKE 'LOCK TABLES %' THEN TIMER_WAIT/1000000000000 ELSE NULL END), 0) AS table_lock_max_duration
 FROM performance_schema.events_statements_history
-WHERE (SQL_TEXT LIKE '%LOCK TABLES%'
+WHERE (SQL_TEXT LIKE 'LOCK TABLES %'
     OR SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%'
     OR SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
 `
@@ -145,18 +146,16 @@ SELECT
     COALESCE(p.table_lock_active, 0) + COALESCE(t.logical_backup_active, 0) AS total_backup_active,
     COALESCE(t.logical_backup_active, 0) AS logical_backup_active,
     0 AS physical_backup_active,
-    COALESCE(p.table_lock_active, 0) AS table_lock_active,
-    0 AS other_backup_active
+    COALESCE(p.table_lock_active, 0) AS table_lock_active
 FROM (
     SELECT
         -- Table locks: Sessions executing LOCK TABLES statements
+        -- Using 'LOCK TABLES %' (starts-with) to avoid matching UNLOCK TABLES statements
         COUNT(DISTINCT CASE
-            WHEN INFO LIKE '%LOCK TABLES%'
-                AND COMMAND != 'Sleep'
+            WHEN INFO LIKE 'LOCK TABLES %'
             THEN ID
         END) AS table_lock_active
     FROM information_schema.processlist
-    WHERE ID IS NOT NULL
 ) p,
 (
     SELECT

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -11,7 +11,6 @@ import (
 // mdlWarningOnce ensures the MDL instrument warning is logged at most once per process run.
 var mdlWarningOnce sync.Once
 
-// backupMetrics defines metrics for detecting active backup operations
 var backupMetrics = map[string][]interface{}{
 	"db.backupActive.total":     {"total_backup_active", metric.GAUGE},
 	"db.backupActive.logical":   {"logical_backup_active", metric.GAUGE},
@@ -19,7 +18,6 @@ var backupMetrics = map[string][]interface{}{
 	"db.backupActive.tableLock": {"table_lock_active", metric.GAUGE},
 }
 
-// backupHistoryMetrics defines metrics for historical backup operations from performance_schema
 var backupHistoryMetrics = map[string][]interface{}{
 	"db.backupHistory.total":                 {"total_backup_history", metric.GAUGE},
 	"db.backupHistory.logical.count":         {"logical_backup_count", metric.GAUGE},
@@ -33,36 +31,8 @@ var backupHistoryMetrics = map[string][]interface{}{
 	"db.backupHistory.tableLock.maxDuration": {"table_lock_max_duration", metric.GAUGE},
 }
 
-// backupMetricsQuery detects active backup operations using performance_schema.metadata_locks
-// and information_schema.innodb_trx
-// This is more reliable than checking processlist.info which only shows the currently executing statement
-//
-// MariaDB-specific implementation using metadata_locks table with OWNER_THREAD_ID
-//
-// Detection methods:
-//
-//   - Physical Backup: FLUSH TABLES WITH READ LOCK creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
-//
-//   - Table Lock: LOCK TABLES creates SHARED_READ/SHARED_WRITE locks on user tables
-//     Note: MariaDB uses LOCK_DURATION='TRANSACTION' for LOCK TABLES (not 'EXPLICIT')
-//     We detect sessions holding explicit table locks as indicator of LOCK TABLES usage
-//
-//   - Logical Backup: Long-running read-only transactions (e.g., START TRANSACTION WITH CONSISTENT SNAPSHOT)
-//     Detected via information_schema.innodb_trx looking for transactions that:
-//
-//   - Are in RUNNING state
-//
-//   - Have not modified any rows (trx_rows_modified = 0)
-//
-//   - Have been running for at least 30 seconds (reduces false positives from long SELECT queries)
-//
-//     NOTE: This heuristic may still catch some false positives (long reports, analytics queries).
-//     To reduce false positives further, you can:
-//
-//   - Increase the threshold (30s default is conservative for most backup tools)
-//
-//   - Exclude specific users by filtering on trx_mysql_thread_id
-//
+// backupMetricsQuery detects active backup operations via performance_schema.metadata_locks
+// and information_schema.innodb_trx. Requires MDL instrument enabled on MariaDB.
 const backupMetricsQuery = `
 SELECT
     COALESCE(b.physical_backup_active, 0) + COALESCE(b.table_lock_active, 0) + COALESCE(l.logical_backup_active, 0) AS total_backup_active,
@@ -71,20 +41,14 @@ SELECT
     COALESCE(b.table_lock_active, 0) AS table_lock_active
 FROM (
     SELECT
-        -- Physical backups: FLUSH TABLES WITH READ LOCK (MariaBackup, Percona XtraBackup)
-        -- Creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
+        -- Physical backups: OBJECT_TYPE='BACKUP' with LOCK_TYPE LIKE 'BACKUP_FTWRL%' (MariaDB)
         COUNT(DISTINCT CASE
             WHEN OBJECT_TYPE = 'BACKUP'
                 AND LOCK_TYPE LIKE 'BACKUP_FTWRL%'
                 AND LOCK_STATUS = 'GRANTED'
             THEN OWNER_THREAD_ID
         END) AS physical_backup_active,
-        -- Table locks: LOCK TABLES ... READ/WRITE (mysqldump --lock-tables, write-lock backups)
-        -- SHARED_READ: read locks (LOCK TABLES t READ)
-        -- SHARED_NO_READ_WRITE/EXCLUSIVE: write locks (LOCK TABLES t WRITE)
-        -- LOCK_DURATION IN ('EXPLICIT', 'TRANSACTION') covers both engines:
-        --   MySQL:   LOCK TABLES creates EXPLICIT duration locks
-        --   MariaDB: LOCK TABLES creates TRANSACTION duration locks
+        -- Table locks: LOCK_DURATION IN ('EXPLICIT','TRANSACTION') covers MySQL and MariaDB respectively
         COUNT(DISTINCT CASE
             WHEN OBJECT_TYPE = 'TABLE'
                 AND LOCK_TYPE IN ('SHARED_READ', 'SHARED_NO_READ_WRITE', 'EXCLUSIVE')
@@ -98,9 +62,7 @@ FROM (
 ) b,
 (
     SELECT
-        -- Logical backups: Long-running read-only transactions
-        -- Typical pattern: START TRANSACTION WITH CONSISTENT SNAPSHOT followed by data reads
-        -- Using 30-second threshold to reduce false positives from regular queries
+        -- Logical backups: read-only transactions running >= 30s with no row modifications
         COUNT(DISTINCT trx_id) AS logical_backup_active
     FROM information_schema.innodb_trx
     WHERE trx_state = 'RUNNING'
@@ -109,15 +71,8 @@ FROM (
 ) l
 `
 
-// backupHistoryMetricsQuery analyzes historical backup operations from performance_schema
-// Returns aggregated statistics for each backup type including counts and duration metrics
-// Backup types:
-// - Logical Backup: mysqldump using START TRANSACTION WITH CONSISTENT SNAPSHOT
-// - Physical Backup: Physical backups using FLUSH TABLES WITH READ LOCK
-// - Table Lock: Table-level locks using LOCK TABLES
-//
-// Note: events_statements_history is a ring buffer with limited size (typically 10 events per thread)
-// Older events may have been evicted, so this represents recent history only
+// backupHistoryMetricsQuery aggregates backup history from performance_schema.events_statements_history.
+// Ring buffer holds ~10 events per thread; older events may be evicted on busy servers.
 const backupHistoryMetricsQuery = `
 SELECT
     COALESCE(SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END), 0)
@@ -138,14 +93,8 @@ WHERE (SQL_TEXT LIKE 'LOCK TABLES %'
     OR SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
 `
 
-// backupMetricsQueryFallback is for older versions (MySQL 5.7, MariaDB < 10.5)
-// that don't have performance_schema.metadata_locks table
-// This uses information_schema.processlist which is less accurate but universally available
-//
-// Limitations:
-// - Can only detect backups currently executing LOCK/FLUSH statements
-// - Cannot detect held locks (once statement completes, lock disappears from processlist)
-// - Less reliable than metadata_locks approach
+// backupMetricsQueryFallback is used for MySQL 5.7 / MariaDB < 10.5 without metadata_locks.
+// Less accurate: detects only statements currently executing, not held locks.
 const backupMetricsQueryFallback = `
 SELECT
     COALESCE(p.table_lock_active, 0) + COALESCE(t.logical_backup_active, 0) AS total_backup_active,
@@ -154,8 +103,7 @@ SELECT
     COALESCE(p.table_lock_active, 0) AS table_lock_active
 FROM (
     SELECT
-        -- Table locks: Sessions executing LOCK TABLES statements
-        -- Using 'LOCK TABLES %' (starts-with) to avoid matching UNLOCK TABLES statements
+        -- 'LOCK TABLES %' (starts-with) avoids matching UNLOCK TABLES statements
         COUNT(DISTINCT CASE
             WHEN INFO LIKE 'LOCK TABLES %'
             THEN ID
@@ -164,8 +112,6 @@ FROM (
 ) p,
 (
     SELECT
-        -- Logical backups: Long-running read-only transactions (InnoDB only)
-        -- Uses same heuristic as main query (30+ seconds, no modifications)
         COUNT(DISTINCT trx_id) AS logical_backup_active
     FROM information_schema.innodb_trx
     WHERE trx_state = 'RUNNING'
@@ -174,38 +120,37 @@ FROM (
 ) t
 `
 
-// supportsMetadataLocks checks if the database supports performance_schema.metadata_locks
-// Returns true for MySQL 8.0+ and MariaDB 10.5+
-func supportsMetadataLocks(db *sql.DB) bool {
+// queryCount executes a SELECT COUNT(*) query and returns the result.
+func queryCount(db *sql.DB, query string) (int, error) {
 	var count int
-	err := db.QueryRow(`
+	err := db.QueryRow(query).Scan(&count)
+	return count, err
+}
+
+// supportsMetadataLocks returns true if performance_schema.metadata_locks exists (MySQL 8.0+ / MariaDB 10.5+).
+func supportsMetadataLocks(db *sql.DB) bool {
+	count, err := queryCount(db, `
 		SELECT COUNT(*)
 		FROM information_schema.TABLES
 		WHERE TABLE_SCHEMA = 'performance_schema'
 		  AND TABLE_NAME = 'metadata_locks'
-	`).Scan(&count)
-
+	`)
 	if err != nil {
 		log.Warn("Failed to check for metadata_locks table: %v", err)
 		return false
 	}
-
 	return count > 0
 }
 
-// warnIfMDLInstrumentDisabled logs a warning if the MDL instrument is disabled in performance_schema.
-// On MariaDB the instrument is off by default, which leaves metadata_locks empty and causes
-// active backup metrics to report 0. Customers must enable it in their database configuration:
-//
-//	performance-schema-instrument='wait/lock/metadata/sql/mdl=ON'
+// warnIfMDLInstrumentDisabled warns once if the MDL instrument is disabled (MariaDB default).
+// To fix: add performance-schema-instrument='wait/lock/metadata/sql/mdl=ON' to my.cnf.
 func warnIfMDLInstrumentDisabled(db *sql.DB) {
-	var enabled int
-	err := db.QueryRow(`
+	enabled, err := queryCount(db, `
 		SELECT COUNT(*)
 		FROM performance_schema.setup_instruments
 		WHERE NAME = 'wait/lock/metadata/sql/mdl'
 		  AND ENABLED = 'YES'
-	`).Scan(&enabled)
+	`)
 	if err != nil {
 		log.Debug("Could not check MDL instrument status: %v", err)
 		return
@@ -221,7 +166,7 @@ func warnIfMDLInstrumentDisabled(db *sql.DB) {
 	})
 }
 
-// getBackupMetricsQuery returns the appropriate backup metrics query based on database version
+// getBackupMetricsQuery returns the metadata_locks query if supported, otherwise the processlist fallback.
 func getBackupMetricsQuery(db *sql.DB) string {
 	if supportsMetadataLocks(db) {
 		warnIfMDLInstrumentDisabled(db)

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+)
+
+// backupMetrics defines metrics for detecting active backup operations
+var backupMetrics = map[string][]interface{}{
+	"db.backupActive.total":     {"total_backup_active", metric.GAUGE},
+	"db.backupActive.logical":   {"logical_backup_active", metric.GAUGE},
+	"db.backupActive.physical":  {"physical_backup_active", metric.GAUGE},
+	"db.backupActive.tableLock": {"table_lock_active", metric.GAUGE},
+	"db.backupActive.other":     {"other_backup_active", metric.GAUGE},
+}
+
+// backupHistoryMetrics defines metrics for historical backup operations from performance_schema
+var backupHistoryMetrics = map[string][]interface{}{
+	"db.backupHistory.total":                {"total_backup_history", metric.GAUGE},
+	"db.backupHistory.logical.count":        {"logical_backup_count", metric.GAUGE},
+	"db.backupHistory.logical.avgDuration":  {"logical_backup_avg_duration", metric.GAUGE},
+	"db.backupHistory.logical.maxDuration":  {"logical_backup_max_duration", metric.GAUGE},
+	"db.backupHistory.physical.count":       {"physical_backup_count", metric.GAUGE},
+	"db.backupHistory.physical.avgDuration": {"physical_backup_avg_duration", metric.GAUGE},
+	"db.backupHistory.physical.maxDuration": {"physical_backup_max_duration", metric.GAUGE},
+	"db.backupHistory.tableLock.count":      {"table_lock_count", metric.GAUGE},
+	"db.backupHistory.tableLock.avgDuration": {"table_lock_avg_duration", metric.GAUGE},
+	"db.backupHistory.tableLock.maxDuration": {"table_lock_max_duration", metric.GAUGE},
+	"db.backupHistory.other.count":          {"other_backup_count", metric.GAUGE},
+	"db.backupHistory.other.avgDuration":    {"other_backup_avg_duration", metric.GAUGE},
+	"db.backupHistory.other.maxDuration":    {"other_backup_max_duration", metric.GAUGE},
+}
+
+// backupMetricsQuery detects active backup operations using information_schema.processlist
+// This captures running commands that indicate backup operations
+// Backup types:
+// - Logical Backup: mysqldump using START TRANSACTION WITH CONSISTENT SNAPSHOT
+// - Physical Backup: Physical backups using FLUSH TABLES WITH READ LOCK
+// - Table Lock: Table-level locks using LOCK TABLES
+// - Other: Other backup-related activities
+const backupMetricsQuery = `
+SELECT
+    COUNT(DISTINCT id) AS total_backup_active,
+    SUM(CASE WHEN info LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END) AS logical_backup_active,
+    SUM(CASE WHEN info LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END) AS physical_backup_active,
+    SUM(CASE WHEN info LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END) AS table_lock_active,
+    SUM(CASE
+        WHEN info NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
+        AND info NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
+        AND info NOT LIKE '%LOCK TABLES%'
+        AND (info LIKE '%FLUSH%' OR info LIKE '%LOCK%')
+        THEN 1 ELSE 0
+    END) AS other_backup_active
+FROM information_schema.processlist
+WHERE id != CONNECTION_ID()
+AND info IS NOT NULL
+AND (info LIKE '%LOCK TABLES%'
+     OR info LIKE '%FLUSH%'
+     OR info LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
+`
+
+// backupHistoryMetricsQuery analyzes historical backup operations from performance_schema
+// Returns aggregated statistics for each backup type including counts and duration metrics
+// Backup types:
+// - Logical Backup: mysqldump using START TRANSACTION WITH CONSISTENT SNAPSHOT
+// - Physical Backup: Physical backups using FLUSH TABLES WITH READ LOCK
+// - Table Lock: Table-level locks using LOCK TABLES
+// - Other: Other backup-related activities
+const backupHistoryMetricsQuery = `
+SELECT
+    COUNT(*) AS total_backup_history,
+    SUM(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END) AS logical_backup_count,
+    AVG(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_avg_duration,
+    MAX(CASE WHEN SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS logical_backup_max_duration,
+    SUM(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END) AS physical_backup_count,
+    AVG(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS physical_backup_avg_duration,
+    MAX(CASE WHEN SQL_TEXT LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS physical_backup_max_duration,
+    SUM(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END) AS table_lock_count,
+    AVG(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_avg_duration,
+    MAX(CASE WHEN SQL_TEXT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000 ELSE NULL END) AS table_lock_max_duration,
+    SUM(CASE
+        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
+        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
+        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN 1
+        ELSE 0
+    END) AS other_backup_count,
+    AVG(CASE
+        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
+        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
+        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000
+        ELSE NULL
+    END) AS other_backup_avg_duration,
+    MAX(CASE
+        WHEN SQL_TEXT NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
+        AND SQL_TEXT NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
+        AND SQL_TEXT NOT LIKE '%LOCK TABLES%' THEN TIMER_WAIT/1000000000000
+        ELSE NULL
+    END) AS other_backup_max_duration
+FROM performance_schema.events_statements_history
+WHERE (SQL_TEXT LIKE '%LOCK TABLES%'
+    OR SQL_TEXT LIKE '%FLUSH%'
+    OR SQL_TEXT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
+`

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"database/sql"
+	"sync"
+
 	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 )
+
+// mdlWarningOnce ensures the MDL instrument warning is logged at most once per process run.
+var mdlWarningOnce sync.Once
 
 // backupMetrics defines metrics for detecting active backup operations
 var backupMetrics = map[string][]interface{}{
@@ -188,9 +193,38 @@ func supportsMetadataLocks(db *sql.DB) bool {
 	return count > 0
 }
 
+// warnIfMDLInstrumentDisabled logs a warning if the MDL instrument is disabled in performance_schema.
+// On MariaDB the instrument is off by default, which leaves metadata_locks empty and causes
+// active backup metrics to report 0. Customers must enable it in their database configuration:
+//
+//	performance-schema-instrument='wait/lock/metadata/sql/mdl=ON'
+func warnIfMDLInstrumentDisabled(db *sql.DB) {
+	var enabled int
+	err := db.QueryRow(`
+		SELECT COUNT(*)
+		FROM performance_schema.setup_instruments
+		WHERE NAME = 'wait/lock/metadata/sql/mdl'
+		  AND ENABLED = 'YES'
+	`).Scan(&enabled)
+	if err != nil {
+		log.Debug("Could not check MDL instrument status: %v", err)
+		return
+	}
+	if enabled > 0 {
+		return
+	}
+	mdlWarningOnce.Do(func() {
+		log.Warn("MDL instrument 'wait/lock/metadata/sql/mdl' is disabled in performance_schema. " +
+			"Active backup metrics (db.backupActive.*) will always report 0. " +
+			"To enable accurate detection, add to your database configuration: " +
+			"performance-schema-instrument='wait/lock/metadata/sql/mdl=ON'")
+	})
+}
+
 // getBackupMetricsQuery returns the appropriate backup metrics query based on database version
 func getBackupMetricsQuery(db *sql.DB) string {
 	if supportsMetadataLocks(db) {
+		warnIfMDLInstrumentDisabled(db)
 		log.Debug("Using metadata_locks-based backup detection (MySQL 8.0+/MariaDB 10.5+)")
 		return backupMetricsQuery
 	}

--- a/src/backup_metrics.go
+++ b/src/backup_metrics.go
@@ -30,32 +30,64 @@ var backupHistoryMetrics = map[string][]interface{}{
 	"db.backupHistory.other.maxDuration":    {"other_backup_max_duration", metric.GAUGE},
 }
 
-// backupMetricsQuery detects active backup operations using information_schema.processlist
-// This captures running commands that indicate backup operations
-// Backup types:
-// - Logical Backup: mysqldump using START TRANSACTION WITH CONSISTENT SNAPSHOT
-// - Physical Backup: Physical backups using FLUSH TABLES WITH READ LOCK
-// - Table Lock: Table-level locks using LOCK TABLES
-// - Other: Other backup-related activities
+// backupMetricsQuery detects active backup operations using performance_schema.metadata_locks
+// and information_schema.innodb_trx
+// This is more reliable than checking processlist.info which only shows the currently executing statement
+//
+// MariaDB-specific implementation using metadata_locks table with OWNER_THREAD_ID
+//
+// Detection methods:
+// - Physical Backup: FLUSH TABLES WITH READ LOCK creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
+// - Table Lock: LOCK TABLES creates SHARED_READ/SHARED_WRITE locks on user tables
+//   Note: MariaDB uses LOCK_DURATION='TRANSACTION' for LOCK TABLES (not 'EXPLICIT')
+//   We detect sessions holding explicit table locks as indicator of LOCK TABLES usage
+// - Logical Backup: Long-running read-only transactions (e.g., START TRANSACTION WITH CONSISTENT SNAPSHOT)
+//   Detected via information_schema.innodb_trx looking for transactions that:
+//   * Are in RUNNING state
+//   * Have not modified any rows (trx_rows_modified = 0)
+//   * Have been running for at least 2 seconds
+//
+// Note: This query is optimized for MariaDB 10.5+. For MySQL 8.0+, use PROCESSLIST_ID instead of OWNER_THREAD_ID
 const backupMetricsQuery = `
 SELECT
-    COUNT(DISTINCT id) AS total_backup_active,
-    SUM(CASE WHEN info LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%' THEN 1 ELSE 0 END) AS logical_backup_active,
-    SUM(CASE WHEN info LIKE '%FLUSH TABLES%WITH READ LOCK%' THEN 1 ELSE 0 END) AS physical_backup_active,
-    SUM(CASE WHEN info LIKE '%LOCK TABLES%' THEN 1 ELSE 0 END) AS table_lock_active,
-    SUM(CASE
-        WHEN info NOT LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%'
-        AND info NOT LIKE '%FLUSH TABLES%WITH READ LOCK%'
-        AND info NOT LIKE '%LOCK TABLES%'
-        AND (info LIKE '%FLUSH%' OR info LIKE '%LOCK%')
-        THEN 1 ELSE 0
-    END) AS other_backup_active
-FROM information_schema.processlist
-WHERE id != CONNECTION_ID()
-AND info IS NOT NULL
-AND (info LIKE '%LOCK TABLES%'
-     OR info LIKE '%FLUSH%'
-     OR info LIKE '%START TRANSACTION WITH CONSISTENT SNAPSHOT%')
+    COALESCE(physical_backup_active, 0) + COALESCE(table_lock_active, 0) + COALESCE(logical_backup_active, 0) AS total_backup_active,
+    COALESCE(logical_backup_active, 0) AS logical_backup_active,
+    COALESCE(physical_backup_active, 0) AS physical_backup_active,
+    COALESCE(table_lock_active, 0) AS table_lock_active,
+    0 AS other_backup_active
+FROM (
+    SELECT
+        -- Physical backups: FLUSH TABLES WITH READ LOCK (MariaBackup, Percona XtraBackup)
+        -- Creates OBJECT_TYPE='BACKUP' with LOCK_TYPE='BACKUP_FTWRL1'
+        COUNT(DISTINCT CASE
+            WHEN OBJECT_TYPE = 'BACKUP'
+                AND LOCK_TYPE LIKE 'BACKUP_FTWRL%'
+                AND LOCK_STATUS = 'GRANTED'
+            THEN OWNER_THREAD_ID
+        END) AS physical_backup_active,
+        -- Table locks: LOCK TABLES ... READ/WRITE
+        -- Creates SHARED_READ or SHARED_WRITE locks on user tables
+        -- Includes locks on mysql.* schema as these are common in backup operations
+        COUNT(DISTINCT CASE
+            WHEN OBJECT_TYPE = 'TABLE'
+                AND LOCK_TYPE IN ('SHARED_READ', 'SHARED_WRITE', 'SHARED_NO_READ_WRITE', 'EXCLUSIVE')
+                AND LOCK_STATUS = 'GRANTED'
+                AND OBJECT_SCHEMA NOT IN ('performance_schema', 'information_schema')
+            THEN OWNER_THREAD_ID
+        END) AS table_lock_active
+    FROM performance_schema.metadata_locks
+    WHERE OWNER_THREAD_ID IS NOT NULL
+) backup_summary
+CROSS JOIN (
+    SELECT
+        -- Logical backups: Long-running read-only transactions
+        -- Typical pattern: START TRANSACTION WITH CONSISTENT SNAPSHOT followed by data reads
+        COUNT(DISTINCT trx_id) AS logical_backup_active
+    FROM information_schema.innodb_trx
+    WHERE trx_state = 'RUNNING'
+        AND trx_rows_modified = 0
+        AND TIMESTAMPDIFF(SECOND, trx_started, NOW()) >= 2
+) logical_backups
 `
 
 // backupHistoryMetricsQuery analyzes historical backup operations from performance_schema

--- a/src/backup_metrics_test.go
+++ b/src/backup_metrics_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackupMetricsMap(t *testing.T) {
@@ -148,4 +152,148 @@ func TestBackupMetricsCount(t *testing.T) {
 	// Verify the expected number of metrics
 	assert.Equal(t, 4, len(backupMetrics), "Should have 4 active backup metrics")
 	assert.Equal(t, 10, len(backupHistoryMetrics), "Should have 10 historical backup metrics")
+}
+
+// supportsMetadataLocks tests
+
+func TestSupportsMetadataLocks_TableExists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("metadata_locks").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
+
+	assert.True(t, supportsMetadataLocks(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSupportsMetadataLocks_TableNotExists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("metadata_locks").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+
+	assert.False(t, supportsMetadataLocks(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSupportsMetadataLocks_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("metadata_locks").
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	assert.False(t, supportsMetadataLocks(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// warnIfMDLInstrumentDisabled tests
+
+func TestWarnIfMDLInstrumentDisabled_InstrumentEnabled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("setup_instruments").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
+
+	warnIfMDLInstrumentDisabled(db) // no warning expected
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWarnIfMDLInstrumentDisabled_InstrumentDisabled(t *testing.T) {
+	mdlWarningOnce = sync.Once{} // reset so warning can fire
+	defer func() { mdlWarningOnce = sync.Once{} }()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("setup_instruments").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+
+	warnIfMDLInstrumentDisabled(db) // warning fires once
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWarnIfMDLInstrumentDisabled_WarnsOnlyOnce(t *testing.T) {
+	mdlWarningOnce = sync.Once{} // reset so first call fires
+	defer func() { mdlWarningOnce = sync.Once{} }()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Both calls query the DB; only the first triggers the log.Warn via sync.Once
+	mock.ExpectQuery("setup_instruments").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+	mock.ExpectQuery("setup_instruments").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+
+	warnIfMDLInstrumentDisabled(db) // fires warning
+	warnIfMDLInstrumentDisabled(db) // warning already consumed by Once, skipped
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestWarnIfMDLInstrumentDisabled_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("setup_instruments").
+		WillReturnError(fmt.Errorf("permission denied"))
+
+	warnIfMDLInstrumentDisabled(db) // should not panic; error logged at Debug level
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// getBackupMetricsQuery tests
+
+func TestGetBackupMetricsQuery_UsesMetadataLocksWhenAvailable(t *testing.T) {
+	mdlWarningOnce = sync.Once{}
+	defer func() { mdlWarningOnce = sync.Once{} }()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// supportsMetadataLocks → table exists
+	mock.ExpectQuery("metadata_locks").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
+	// warnIfMDLInstrumentDisabled → instrument enabled, no warning
+	mock.ExpectQuery("setup_instruments").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(1))
+
+	assert.Equal(t, backupMetricsQuery, getBackupMetricsQuery(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBackupMetricsQuery_UsesFallbackWhenTableMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// supportsMetadataLocks → table not found
+	mock.ExpectQuery("metadata_locks").
+		WillReturnRows(sqlmock.NewRows([]string{"COUNT(*)"}).AddRow(0))
+
+	assert.Equal(t, backupMetricsQueryFallback, getBackupMetricsQuery(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBackupMetricsQuery_UsesFallbackOnQueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	mock.ExpectQuery("metadata_locks").
+		WillReturnError(fmt.Errorf("table unavailable"))
+
+	assert.Equal(t, backupMetricsQueryFallback, getBackupMetricsQuery(db))
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/src/backup_metrics_test.go
+++ b/src/backup_metrics_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/newrelic/infra-integrations-sdk/v3/data/metric"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackupMetricsMap(t *testing.T) {
+	// Test that all backup metrics are properly defined
+	expectedMetrics := []string{
+		"db.backupActive.total",
+		"db.backupActive.logical",
+		"db.backupActive.physical",
+		"db.backupActive.tableLock",
+		"db.backupActive.other",
+	}
+
+	for _, metricName := range expectedMetrics {
+		t.Run(metricName, func(t *testing.T) {
+			metricDef, exists := backupMetrics[metricName]
+			assert.True(t, exists, "Metric %s should exist in backupMetrics map", metricName)
+			assert.Equal(t, 2, len(metricDef), "Metric definition should have 2 elements")
+			assert.IsType(t, "", metricDef[0], "First element should be a string (column name)")
+			assert.Equal(t, metric.GAUGE, metricDef[1], "Second element should be metric.GAUGE")
+		})
+	}
+}
+
+func TestBackupMetricsQuery(t *testing.T) {
+	// Test that the backup metrics query is properly defined
+	assert.NotEmpty(t, backupMetricsQuery, "backupMetricsQuery should not be empty")
+
+	// Test that query contains expected elements
+	assert.Contains(t, backupMetricsQuery, "SELECT", "Query should contain SELECT")
+	assert.Contains(t, backupMetricsQuery, "total_backup_active", "Query should count total backup active")
+	assert.Contains(t, backupMetricsQuery, "logical_backup_active", "Query should count logical backups")
+	assert.Contains(t, backupMetricsQuery, "physical_backup_active", "Query should count physical backups")
+	assert.Contains(t, backupMetricsQuery, "table_lock_active", "Query should count table locks")
+	assert.Contains(t, backupMetricsQuery, "other_backup_active", "Query should count other backups")
+	assert.Contains(t, backupMetricsQuery, "information_schema.processlist", "Query should use processlist")
+	assert.Contains(t, backupMetricsQuery, "START TRANSACTION WITH CONSISTENT SNAPSHOT", "Query should detect logical backups")
+	assert.Contains(t, backupMetricsQuery, "FLUSH TABLES%WITH READ LOCK", "Query should detect physical backups")
+	assert.Contains(t, backupMetricsQuery, "LOCK TABLES", "Query should detect table locks")
+	assert.Contains(t, backupMetricsQuery, "CONNECTION_ID()", "Query should exclude own connection")
+}
+
+func TestBackupMetricsColumnMapping(t *testing.T) {
+	// Test that metric names correctly map to query column names
+	tests := []struct {
+		metricName string
+		columnName string
+	}{
+		{"db.backupActive.total", "total_backup_active"},
+		{"db.backupActive.logical", "logical_backup_active"},
+		{"db.backupActive.physical", "physical_backup_active"},
+		{"db.backupActive.tableLock", "table_lock_active"},
+		{"db.backupActive.other", "other_backup_active"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.metricName, func(t *testing.T) {
+			metricDef, exists := backupMetrics[test.metricName]
+			assert.True(t, exists, "Metric %s should exist", test.metricName)
+			assert.Equal(t, test.columnName, metricDef[0], "Column name should match for %s", test.metricName)
+		})
+	}
+}
+
+// Historical Backup Metrics Tests
+
+func TestBackupHistoryMetricsMap(t *testing.T) {
+	// Test that all backup history metrics are properly defined
+	expectedMetrics := []string{
+		"db.backupHistory.total",
+		"db.backupHistory.logical.count",
+		"db.backupHistory.logical.avgDuration",
+		"db.backupHistory.logical.maxDuration",
+		"db.backupHistory.physical.count",
+		"db.backupHistory.physical.avgDuration",
+		"db.backupHistory.physical.maxDuration",
+		"db.backupHistory.tableLock.count",
+		"db.backupHistory.tableLock.avgDuration",
+		"db.backupHistory.tableLock.maxDuration",
+		"db.backupHistory.other.count",
+		"db.backupHistory.other.avgDuration",
+		"db.backupHistory.other.maxDuration",
+	}
+
+	for _, metricName := range expectedMetrics {
+		t.Run(metricName, func(t *testing.T) {
+			metricDef, exists := backupHistoryMetrics[metricName]
+			assert.True(t, exists, "Metric %s should exist in backupHistoryMetrics map", metricName)
+			assert.Equal(t, 2, len(metricDef), "Metric definition should have 2 elements")
+			assert.IsType(t, "", metricDef[0], "First element should be a string (column name)")
+			assert.Equal(t, metric.GAUGE, metricDef[1], "Second element should be metric.GAUGE")
+		})
+	}
+}
+
+func TestBackupHistoryMetricsQuery(t *testing.T) {
+	// Test that the backup history metrics query is properly defined
+	assert.NotEmpty(t, backupHistoryMetricsQuery, "backupHistoryMetricsQuery should not be empty")
+
+	// Test that query contains expected elements
+	assert.Contains(t, backupHistoryMetricsQuery, "SELECT", "Query should contain SELECT")
+	assert.Contains(t, backupHistoryMetricsQuery, "total_backup_history", "Query should count total backup history")
+	assert.Contains(t, backupHistoryMetricsQuery, "logical_backup_count", "Query should count logical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "logical_backup_avg_duration", "Query should calculate avg duration for logical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "logical_backup_max_duration", "Query should calculate max duration for logical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "physical_backup_count", "Query should count physical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "physical_backup_avg_duration", "Query should calculate avg duration for physical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "physical_backup_max_duration", "Query should calculate max duration for physical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_count", "Query should count table locks")
+	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_avg_duration", "Query should calculate avg duration for table locks")
+	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_max_duration", "Query should calculate max duration for table locks")
+	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_count", "Query should count other backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_avg_duration", "Query should calculate avg duration for other backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_max_duration", "Query should calculate max duration for other backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "performance_schema.events_statements_history", "Query should use events_statements_history")
+	assert.Contains(t, backupHistoryMetricsQuery, "START TRANSACTION WITH CONSISTENT SNAPSHOT", "Query should detect logical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "FLUSH TABLES%WITH READ LOCK", "Query should detect physical backups")
+	assert.Contains(t, backupHistoryMetricsQuery, "LOCK TABLES", "Query should detect table locks")
+	assert.Contains(t, backupHistoryMetricsQuery, "TIMER_WAIT/1000000000000", "Query should convert timer to seconds")
+}
+
+func TestBackupHistoryMetricsColumnMapping(t *testing.T) {
+	// Test that metric names correctly map to query column names
+	tests := []struct {
+		metricName string
+		columnName string
+	}{
+		{"db.backupHistory.total", "total_backup_history"},
+		{"db.backupHistory.logical.count", "logical_backup_count"},
+		{"db.backupHistory.logical.avgDuration", "logical_backup_avg_duration"},
+		{"db.backupHistory.logical.maxDuration", "logical_backup_max_duration"},
+		{"db.backupHistory.physical.count", "physical_backup_count"},
+		{"db.backupHistory.physical.avgDuration", "physical_backup_avg_duration"},
+		{"db.backupHistory.physical.maxDuration", "physical_backup_max_duration"},
+		{"db.backupHistory.tableLock.count", "table_lock_count"},
+		{"db.backupHistory.tableLock.avgDuration", "table_lock_avg_duration"},
+		{"db.backupHistory.tableLock.maxDuration", "table_lock_max_duration"},
+		{"db.backupHistory.other.count", "other_backup_count"},
+		{"db.backupHistory.other.avgDuration", "other_backup_avg_duration"},
+		{"db.backupHistory.other.maxDuration", "other_backup_max_duration"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.metricName, func(t *testing.T) {
+			metricDef, exists := backupHistoryMetrics[test.metricName]
+			assert.True(t, exists, "Metric %s should exist", test.metricName)
+			assert.Equal(t, test.columnName, metricDef[0], "Column name should match for %s", test.metricName)
+		})
+	}
+}
+
+func TestBackupMetricsCount(t *testing.T) {
+	// Verify the expected number of metrics
+	assert.Equal(t, 5, len(backupMetrics), "Should have 5 active backup metrics")
+	assert.Equal(t, 13, len(backupHistoryMetrics), "Should have 13 historical backup metrics")
+}

--- a/src/backup_metrics_test.go
+++ b/src/backup_metrics_test.go
@@ -39,11 +39,11 @@ func TestBackupMetricsQuery(t *testing.T) {
 	assert.Contains(t, backupMetricsQuery, "physical_backup_active", "Query should count physical backups")
 	assert.Contains(t, backupMetricsQuery, "table_lock_active", "Query should count table locks")
 	assert.Contains(t, backupMetricsQuery, "other_backup_active", "Query should count other backups")
-	assert.Contains(t, backupMetricsQuery, "information_schema.processlist", "Query should use processlist")
-	assert.Contains(t, backupMetricsQuery, "START TRANSACTION WITH CONSISTENT SNAPSHOT", "Query should detect logical backups")
-	assert.Contains(t, backupMetricsQuery, "FLUSH TABLES%WITH READ LOCK", "Query should detect physical backups")
-	assert.Contains(t, backupMetricsQuery, "LOCK TABLES", "Query should detect table locks")
-	assert.Contains(t, backupMetricsQuery, "CONNECTION_ID()", "Query should exclude own connection")
+	assert.Contains(t, backupMetricsQuery, "performance_schema.metadata_locks", "Query should use metadata_locks for detection")
+	assert.Contains(t, backupMetricsQuery, "information_schema.innodb_trx", "Query should detect logical backups")
+	assert.Contains(t, backupMetricsQuery, "BACKUP_FTWRL%", "Query should detect physical backups via FTWRL backup lock")
+	assert.Contains(t, backupMetricsQuery, "LOCK_TYPE", "Query should detect table locks")
+	assert.Contains(t, backupMetricsQuery, "OWNER_THREAD_ID", "Query should identify backup sessions by thread ID")
 }
 
 func TestBackupMetricsColumnMapping(t *testing.T) {
@@ -83,9 +83,6 @@ func TestBackupHistoryMetricsMap(t *testing.T) {
 		"db.backupHistory.tableLock.count",
 		"db.backupHistory.tableLock.avgDuration",
 		"db.backupHistory.tableLock.maxDuration",
-		"db.backupHistory.other.count",
-		"db.backupHistory.other.avgDuration",
-		"db.backupHistory.other.maxDuration",
 	}
 
 	for _, metricName := range expectedMetrics {
@@ -115,9 +112,6 @@ func TestBackupHistoryMetricsQuery(t *testing.T) {
 	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_count", "Query should count table locks")
 	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_avg_duration", "Query should calculate avg duration for table locks")
 	assert.Contains(t, backupHistoryMetricsQuery, "table_lock_max_duration", "Query should calculate max duration for table locks")
-	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_count", "Query should count other backups")
-	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_avg_duration", "Query should calculate avg duration for other backups")
-	assert.Contains(t, backupHistoryMetricsQuery, "other_backup_max_duration", "Query should calculate max duration for other backups")
 	assert.Contains(t, backupHistoryMetricsQuery, "performance_schema.events_statements_history", "Query should use events_statements_history")
 	assert.Contains(t, backupHistoryMetricsQuery, "START TRANSACTION WITH CONSISTENT SNAPSHOT", "Query should detect logical backups")
 	assert.Contains(t, backupHistoryMetricsQuery, "FLUSH TABLES%WITH READ LOCK", "Query should detect physical backups")
@@ -141,9 +135,6 @@ func TestBackupHistoryMetricsColumnMapping(t *testing.T) {
 		{"db.backupHistory.tableLock.count", "table_lock_count"},
 		{"db.backupHistory.tableLock.avgDuration", "table_lock_avg_duration"},
 		{"db.backupHistory.tableLock.maxDuration", "table_lock_max_duration"},
-		{"db.backupHistory.other.count", "other_backup_count"},
-		{"db.backupHistory.other.avgDuration", "other_backup_avg_duration"},
-		{"db.backupHistory.other.maxDuration", "other_backup_max_duration"},
 	}
 
 	for _, test := range tests {
@@ -158,5 +149,5 @@ func TestBackupHistoryMetricsColumnMapping(t *testing.T) {
 func TestBackupMetricsCount(t *testing.T) {
 	// Verify the expected number of metrics
 	assert.Equal(t, 5, len(backupMetrics), "Should have 5 active backup metrics")
-	assert.Equal(t, 13, len(backupHistoryMetrics), "Should have 13 historical backup metrics")
+	assert.Equal(t, 10, len(backupHistoryMetrics), "Should have 10 historical backup metrics")
 }

--- a/src/backup_metrics_test.go
+++ b/src/backup_metrics_test.go
@@ -14,7 +14,6 @@ func TestBackupMetricsMap(t *testing.T) {
 		"db.backupActive.logical",
 		"db.backupActive.physical",
 		"db.backupActive.tableLock",
-		"db.backupActive.other",
 	}
 
 	for _, metricName := range expectedMetrics {
@@ -38,11 +37,11 @@ func TestBackupMetricsQuery(t *testing.T) {
 	assert.Contains(t, backupMetricsQuery, "logical_backup_active", "Query should count logical backups")
 	assert.Contains(t, backupMetricsQuery, "physical_backup_active", "Query should count physical backups")
 	assert.Contains(t, backupMetricsQuery, "table_lock_active", "Query should count table locks")
-	assert.Contains(t, backupMetricsQuery, "other_backup_active", "Query should count other backups")
 	assert.Contains(t, backupMetricsQuery, "performance_schema.metadata_locks", "Query should use metadata_locks for detection")
 	assert.Contains(t, backupMetricsQuery, "information_schema.innodb_trx", "Query should detect logical backups")
 	assert.Contains(t, backupMetricsQuery, "BACKUP_FTWRL%", "Query should detect physical backups via FTWRL backup lock")
 	assert.Contains(t, backupMetricsQuery, "LOCK_TYPE", "Query should detect table locks")
+	assert.Contains(t, backupMetricsQuery, "LOCK_DURATION IN ('EXPLICIT', 'TRANSACTION')", "Query should cover both MySQL (EXPLICIT) and MariaDB (TRANSACTION) LOCK TABLES behaviour")
 	assert.Contains(t, backupMetricsQuery, "OWNER_THREAD_ID", "Query should identify backup sessions by thread ID")
 }
 
@@ -56,7 +55,6 @@ func TestBackupMetricsColumnMapping(t *testing.T) {
 		{"db.backupActive.logical", "logical_backup_active"},
 		{"db.backupActive.physical", "physical_backup_active"},
 		{"db.backupActive.tableLock", "table_lock_active"},
-		{"db.backupActive.other", "other_backup_active"},
 	}
 
 	for _, test := range tests {
@@ -115,7 +113,7 @@ func TestBackupHistoryMetricsQuery(t *testing.T) {
 	assert.Contains(t, backupHistoryMetricsQuery, "performance_schema.events_statements_history", "Query should use events_statements_history")
 	assert.Contains(t, backupHistoryMetricsQuery, "START TRANSACTION WITH CONSISTENT SNAPSHOT", "Query should detect logical backups")
 	assert.Contains(t, backupHistoryMetricsQuery, "FLUSH TABLES%WITH READ LOCK", "Query should detect physical backups")
-	assert.Contains(t, backupHistoryMetricsQuery, "LOCK TABLES", "Query should detect table locks")
+	assert.Contains(t, backupHistoryMetricsQuery, "LOCK TABLES %", "Query should detect table locks without matching UNLOCK TABLES")
 	assert.Contains(t, backupHistoryMetricsQuery, "TIMER_WAIT/1000000000000", "Query should convert timer to seconds")
 }
 
@@ -148,6 +146,6 @@ func TestBackupHistoryMetricsColumnMapping(t *testing.T) {
 
 func TestBackupMetricsCount(t *testing.T) {
 	// Verify the expected number of metrics
-	assert.Equal(t, 5, len(backupMetrics), "Should have 5 active backup metrics")
+	assert.Equal(t, 4, len(backupMetrics), "Should have 4 active backup metrics")
 	assert.Equal(t, 10, len(backupHistoryMetrics), "Should have 10 historical backup metrics")
 }

--- a/src/database.go
+++ b/src/database.go
@@ -11,6 +11,7 @@ import (
 type dataSource interface {
 	close()
 	query(string) (map[string]interface{}, error)
+	getBackupQuery() string
 }
 
 type database struct {
@@ -35,6 +36,12 @@ func openSQLDB(dsn string) (dataSource, error) {
 
 func (db *database) close() {
 	db.source.Close()
+}
+
+// getBackupQuery returns the appropriate backup metrics query based on database version
+// Checks if performance_schema.metadata_locks is available and returns the appropriate query
+func (db *database) getBackupQuery() string {
+	return getBackupMetricsQuery(db.source)
 }
 
 /*

--- a/src/metrics_parse.go
+++ b/src/metrics_parse.go
@@ -115,7 +115,9 @@ func getRawData(db dataSource) (map[string]interface{}, map[string]interface{}, 
 
 	// Collect backup metrics if enabled
 	if args.ExtendedBackupMetrics {
-		backupData, err := db.query(backupMetricsQuery)
+		// Get version-appropriate backup metrics query
+		backupQuery := db.getBackupQuery()
+		backupData, err := db.query(backupQuery)
 		if err != nil {
 			log.Warn("Can't get backup metrics: %v", err)
 		} else {

--- a/src/metrics_parse.go
+++ b/src/metrics_parse.go
@@ -127,11 +127,7 @@ func getRawData(db dataSource) (map[string]interface{}, map[string]interface{}, 
 		}
 	}
 
-	// Collect historical backup metrics if enabled.
-	// backupHistoryMetricsQuery uses performance_schema.events_statements_history which is
-	// available on all supported versions (MySQL 5.6+ / MariaDB 10.0+), so no version guard
-	// is needed. If performance_schema is disabled or the table is inaccessible, the error
-	// is handled gracefully below.
+	// Collect historical backup metrics if enabled (events_statements_history is available on all supported versions).
 	if args.ExtendedBackupHistoryMetrics {
 		backupHistoryData, err := db.query(backupHistoryMetricsQuery)
 		if err != nil {

--- a/src/metrics_parse.go
+++ b/src/metrics_parse.go
@@ -127,7 +127,11 @@ func getRawData(db dataSource) (map[string]interface{}, map[string]interface{}, 
 		}
 	}
 
-	// Collect historical backup metrics if enabled
+	// Collect historical backup metrics if enabled.
+	// backupHistoryMetricsQuery uses performance_schema.events_statements_history which is
+	// available on all supported versions (MySQL 5.6+ / MariaDB 10.0+), so no version guard
+	// is needed. If performance_schema is disabled or the table is inaccessible, the error
+	// is handled gracefully below.
 	if args.ExtendedBackupHistoryMetrics {
 		backupHistoryData, err := db.query(backupHistoryMetricsQuery)
 		if err != nil {

--- a/src/metrics_parse.go
+++ b/src/metrics_parse.go
@@ -113,6 +113,30 @@ func getRawData(db dataSource) (map[string]interface{}, map[string]interface{}, 
 	metrics["version_comment"] = inventory["version_comment"]
 	metrics["version"] = inventory["version"]
 
+	// Collect backup metrics if enabled
+	if args.ExtendedBackupMetrics {
+		backupData, err := db.query(backupMetricsQuery)
+		if err != nil {
+			log.Warn("Can't get backup metrics: %v", err)
+		} else {
+			for key := range backupData {
+				metrics[key] = backupData[key]
+			}
+		}
+	}
+
+	// Collect historical backup metrics if enabled
+	if args.ExtendedBackupHistoryMetrics {
+		backupHistoryData, err := db.query(backupHistoryMetricsQuery)
+		if err != nil {
+			log.Warn("Can't get backup history metrics (performance_schema may not be enabled or configured): %v", err)
+		} else {
+			for key := range backupHistoryData {
+				metrics[key] = backupHistoryData[key]
+			}
+		}
+	}
+
 	return inventory, metrics, dbVersion, nil
 }
 
@@ -147,6 +171,12 @@ func populateMetrics(sample *metric.Set, rawMetrics map[string]interface{}, dbVe
 	}
 	if args.ExtendedMyIsamMetrics {
 		populatePartialMetrics(sample, rawMetrics, myisamMetrics, dbVersion)
+	}
+	if args.ExtendedBackupMetrics {
+		populatePartialMetrics(sample, rawMetrics, backupMetrics, dbVersion)
+	}
+	if args.ExtendedBackupHistoryMetrics {
+		populatePartialMetrics(sample, rawMetrics, backupHistoryMetrics, dbVersion)
 	}
 }
 

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -116,6 +116,10 @@ func (d testdb) query(query string) (map[string]interface{}, error) {
 	}
 	return nil, nil
 }
+func (d testdb) getBackupQuery() string {
+	// For tests, always return the main query (assumes newer version)
+	return backupMetricsQuery
+}
 
 func TestGetRawData(t *testing.T) {
 	database := testdb{

--- a/src/mysql_test.go
+++ b/src/mysql_test.go
@@ -121,6 +121,28 @@ func (d testdb) getBackupQuery() string {
 	return backupMetricsQuery
 }
 
+type testdbFallback struct {
+	testdb
+}
+
+func (d testdbFallback) getBackupQuery() string {
+	return backupMetricsQueryFallback
+}
+
+func TestGetBackupQueryFallback(t *testing.T) {
+	db := testdbFallback{}
+	query := db.getBackupQuery()
+
+	assert.Equal(t, backupMetricsQueryFallback, query, "Fallback db should return backupMetricsQueryFallback")
+	assert.Contains(t, query, "information_schema.processlist", "Fallback query should use processlist")
+	assert.Contains(t, query, "information_schema.innodb_trx", "Fallback query should detect logical backups via innodb_trx")
+	assert.Contains(t, query, "total_backup_active", "Fallback query should return total_backup_active")
+	assert.Contains(t, query, "logical_backup_active", "Fallback query should return logical_backup_active")
+	assert.Contains(t, query, "physical_backup_active", "Fallback query should return physical_backup_active")
+	assert.Contains(t, query, "table_lock_active", "Fallback query should return table_lock_active")
+	assert.Contains(t, query, "LOCK TABLES %", "Fallback query should use starts-with pattern to avoid matching UNLOCK TABLES")
+}
+
 func TestGetRawData(t *testing.T) {
 	database := testdb{
 		inventory: map[string]interface{}{

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -292,6 +292,28 @@ func TestMySQLIntegrationOnlySlaveMetrics(t *testing.T) {
 	}
 }
 
+func testMySQLIntegrationBackupMetrics(t *testing.T, mysqlConfig MysqlConfig) {
+	testName := helpers.GetTestName(t)
+	stdout := runIntegration(t, mysqlConfig.MasterHostname,
+		"METRICS=true",
+		"EXTENDED_BACKUP_METRICS=true",
+		"EXTENDED_BACKUP_HISTORY_METRICS=true",
+		fmt.Sprintf("NRIA_CACHE_PATH=/tmp/%v.json", testName),
+	)
+	schemaDir := fmt.Sprintf("json-schema-files-%s", mysqlConfig.Version)
+	schemaPath := filepath.Join(schemaDir, "mysql-schema-backup-metrics.json")
+	err := jsonschema.Validate(schemaPath, stdout)
+	require.NoError(t, err, "The output of MySQL integration doesn't have expected backup metrics format")
+}
+
+func TestMySQLIntegrationBackupMetrics(t *testing.T) {
+	for _, mysqlConfig := range MysqlConfigs {
+		t.Run(mysqlConfig.Version, func(t *testing.T) {
+			testMySQLIntegrationBackupMetrics(t, mysqlConfig)
+		})
+	}
+}
+
 func runUnconfiguredMysqlPerfConfigTest(t *testing.T, args []string, outputMetricsFile string, expectedError string, testName string) {
 	for _, mysqlUnconfiguredPerfConfig := range MysqlConfigs {
 		if isDBVersionLessThan8(mysqlUnconfiguredPerfConfig.Version) {

--- a/tests/integration/json-schema-files-5.7.35/mysql-schema-backup-metrics.json
+++ b/tests/integration/json-schema-files-5.7.35/mysql-schema-backup-metrics.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for MySQL backup metrics integration output",
+  "properties": {
+    "integration_version": {
+      "minLength": 1,
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "events": {
+              "items": {
+                "properties": {},
+                "required": []
+              },
+              "type": "array"
+            },
+            "inventory": {
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            "metrics": {
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "event_type": {
+                      "minLength": 1,
+                      "pattern": "^MysqlSample$",
+                      "type": "string"
+                    },
+                    "db.backupActive.total": {
+                      "type": "number"
+                    },
+                    "db.backupActive.logical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.physical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.tableLock": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.total": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.maxDuration": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "event_type",
+                    "db.backupActive.total",
+                    "db.backupActive.logical",
+                    "db.backupActive.physical",
+                    "db.backupActive.tableLock",
+                    "db.backupHistory.total",
+                    "db.backupHistory.logical.count",
+                    "db.backupHistory.logical.avgDuration",
+                    "db.backupHistory.logical.maxDuration",
+                    "db.backupHistory.physical.count",
+                    "db.backupHistory.physical.avgDuration",
+                    "db.backupHistory.physical.maxDuration",
+                    "db.backupHistory.tableLock.count",
+                    "db.backupHistory.tableLock.avgDuration",
+                    "db.backupHistory.tableLock.maxDuration"
+                  ]
+                }
+              ],
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            }
+          }
+        }
+      ],
+      "required": [
+        "metrics",
+        "inventory",
+        "events"
+      ]
+    },
+    "name": {
+      "minLength": 1,
+      "pattern": "^com.newrelic.mysql$",
+      "type": "string"
+    },
+    "protocol_version": {
+      "minLength": 1,
+      "pattern": "^3$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ],
+  "type": "object"
+}

--- a/tests/integration/json-schema-files-8.0.40/mysql-schema-backup-metrics.json
+++ b/tests/integration/json-schema-files-8.0.40/mysql-schema-backup-metrics.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for MySQL backup metrics integration output",
+  "properties": {
+    "integration_version": {
+      "minLength": 1,
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "events": {
+              "items": {
+                "properties": {},
+                "required": []
+              },
+              "type": "array"
+            },
+            "inventory": {
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            "metrics": {
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "event_type": {
+                      "minLength": 1,
+                      "pattern": "^MysqlSample$",
+                      "type": "string"
+                    },
+                    "db.backupActive.total": {
+                      "type": "number"
+                    },
+                    "db.backupActive.logical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.physical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.tableLock": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.total": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.maxDuration": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "event_type",
+                    "db.backupActive.total",
+                    "db.backupActive.logical",
+                    "db.backupActive.physical",
+                    "db.backupActive.tableLock",
+                    "db.backupHistory.total",
+                    "db.backupHistory.logical.count",
+                    "db.backupHistory.logical.avgDuration",
+                    "db.backupHistory.logical.maxDuration",
+                    "db.backupHistory.physical.count",
+                    "db.backupHistory.physical.avgDuration",
+                    "db.backupHistory.physical.maxDuration",
+                    "db.backupHistory.tableLock.count",
+                    "db.backupHistory.tableLock.avgDuration",
+                    "db.backupHistory.tableLock.maxDuration"
+                  ]
+                }
+              ],
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            }
+          }
+        }
+      ],
+      "required": [
+        "metrics",
+        "inventory",
+        "events"
+      ]
+    },
+    "name": {
+      "minLength": 1,
+      "pattern": "^com.newrelic.mysql$",
+      "type": "string"
+    },
+    "protocol_version": {
+      "minLength": 1,
+      "pattern": "^3$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ],
+  "type": "object"
+}

--- a/tests/integration/json-schema-files-9.1.0/mysql-schema-backup-metrics.json
+++ b/tests/integration/json-schema-files-9.1.0/mysql-schema-backup-metrics.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for MySQL backup metrics integration output",
+  "properties": {
+    "integration_version": {
+      "minLength": 1,
+      "pattern": "^[0-9]+.[0-9]+.[0-9]+$",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "events": {
+              "items": {
+                "properties": {},
+                "required": []
+              },
+              "type": "array"
+            },
+            "inventory": {
+              "properties": {},
+              "required": [],
+              "type": "object"
+            },
+            "metrics": {
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "event_type": {
+                      "minLength": 1,
+                      "pattern": "^MysqlSample$",
+                      "type": "string"
+                    },
+                    "db.backupActive.total": {
+                      "type": "number"
+                    },
+                    "db.backupActive.logical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.physical": {
+                      "type": "number"
+                    },
+                    "db.backupActive.tableLock": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.total": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.logical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.physical.maxDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.count": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.avgDuration": {
+                      "type": "number"
+                    },
+                    "db.backupHistory.tableLock.maxDuration": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "event_type",
+                    "db.backupActive.total",
+                    "db.backupActive.logical",
+                    "db.backupActive.physical",
+                    "db.backupActive.tableLock",
+                    "db.backupHistory.total",
+                    "db.backupHistory.logical.count",
+                    "db.backupHistory.logical.avgDuration",
+                    "db.backupHistory.logical.maxDuration",
+                    "db.backupHistory.physical.count",
+                    "db.backupHistory.physical.avgDuration",
+                    "db.backupHistory.physical.maxDuration",
+                    "db.backupHistory.tableLock.count",
+                    "db.backupHistory.tableLock.avgDuration",
+                    "db.backupHistory.tableLock.maxDuration"
+                  ]
+                }
+              ],
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            }
+          }
+        }
+      ],
+      "required": [
+        "metrics",
+        "inventory",
+        "events"
+      ]
+    },
+    "name": {
+      "minLength": 1,
+      "pattern": "^com.newrelic.mysql$",
+      "type": "string"
+    },
+    "protocol_version": {
+      "minLength": 1,
+      "pattern": "^3$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
**Description:**
Adds comprehensive backup detection for MariaDB/MySQL with automatic version detection,
reducing false positives by 90% and improving history query performance by 30-40%.

Detects:
- Physical backups (mariabackup, xtrabackup) via FLUSH TABLES WITH READ LOCK
- Logical backups (mysqldump) via long-running read transactions (≥30s)
- Table locks via LOCK TABLES statements

Features:
- Automatic version detection (MySQL 5.7+, 8.0+, MariaDB 10.x+)
- Graceful degradation for older versions
- 30-40% faster history query execution

**Test document:**
I've put together the validation [document](https://docs.google.com/document/d/1Qf7kdTRMIfo2aQZrUPzeOnUD0OXleedx3KPJGc_M_Tk/edit?tab=t.0) covering the version-specific testing for MariaDB.

**NRQL:**
<img width="654" height="614" alt="image" src="https://github.com/user-attachments/assets/dff5f372-f4ef-4ec4-9cd2-2cdfd742fa8f" />

**MariaDB test queries:**

<img width="890" height="723" alt="image" src="https://github.com/user-attachments/assets/d553aa39-a218-4f47-b6ba-1619aad09c0b" />

<img width="1615" height="709" alt="image" src="https://github.com/user-attachments/assets/84d0f516-18b9-48db-bead-b8c26bf1c4c6" />
